### PR TITLE
Color refactor

### DIFF
--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -97,21 +97,21 @@ public:
             gui.ctx.start_window(fpsString.c_str(), winX, winY);
             for(int i = 0; i < 4; ++i) {
                 rect.x -= 10; rect.y = 40 * i;
-                color.red += 25; color.green += 25;
+                color.red() += 25; color.green() += 25;
                 std::string title = "some  " + std::to_string(i + 1);
                 if(gui.ctx.button(title.c_str(), rect, color)) {
                     std::cout << "Button " << (i + 1) << ": pressed" << std::endl;
                 }
             }
             
-            color.green += 50;
+            color.green() += 50;
             rect.y += 40; rect.width += 50;
             static float sliderValue0 = 20;
             if(gui.ctx.slider(rect, color, sliderValue0, 20, 40, 5)) {
                 std::cout << "Slider 1: new value " << sliderValue0 << std::endl;
             }
             
-            color.green += 50;
+            color.green() += 50;
             rect.y += 40;
             rect.width += 50;
             
@@ -131,14 +131,14 @@ public:
             }
             
             static bool checkBox1 = false;
-            color.red += 15; color.green -= 35; color.blue -= 10;
+            color.red() += 15; color.green() -= 35; color.blue() -= 10;
             rect.x += 270; rect.width = 40; rect.height = 20;
             if(gui.ctx.checkbox(rect, color, checkBox1)) {
                 std::cout << "Checkbox 1: new value " << checkBox1 << std::endl;
             }
             
             static bool checkBox2 = true;
-            color.red -= 100; color.green += 100; color.blue += 100;
+            color.red() -= 100; color.green() += 100; color.blue() += 100;
             rect.y -= 100; rect.width = rect.height = 50;
             if(gui.ctx.checkbox(rect, color, checkBox2)) {
                 std::cout << "Checkbox 2: new value " << checkBox2 << std::endl;

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -91,6 +91,7 @@ public:
             
             // ================== GUI setup =================
             using namespace reig::Colors::literals;
+            using namespace reig::Colors::mixing;
 
             reig::Rectangle rect {40, 0, 100, 30};
             reig::Color color {120_r, 100_g, 150_b};
@@ -99,21 +100,21 @@ public:
             gui.ctx.start_window(fpsString.c_str(), winX, winY);
             for(int i = 0; i < 4; ++i) {
                 rect.x -= 10; rect.y = 40 * i;
-                color.red.val += 25; color.green.val += 25;
+                color = color + 25_r + 25_g;
                 std::string title = "some  " + std::to_string(i + 1);
                 if(gui.ctx.button(title.c_str(), rect, color)) {
                     std::cout << "Button " << (i + 1) << ": pressed" << std::endl;
                 }
             }
-            
-            color.green.val += 50;
+
+            color = color + 50_g;
             rect.y += 40; rect.width += 50;
             static float sliderValue0 = 20;
             if(gui.ctx.slider(rect, color, sliderValue0, 20, 40, 5)) {
                 std::cout << "Slider 1: new value " << sliderValue0 << std::endl;
             }
-            
-            color.green.val += 50;
+
+            color = color + 50_g;
             rect.y += 40;
             rect.width += 50;
             
@@ -133,14 +134,14 @@ public:
             }
             
             static bool checkBox1 = false;
-            color.red.val += 15; color.green.val -= 35; color.blue.val -= 10;
+            color = color + 15_r - 35_r - 10_b;
             rect.x += 270; rect.width = 40; rect.height = 20;
             if(gui.ctx.checkbox(rect, color, checkBox1)) {
                 std::cout << "Checkbox 1: new value " << checkBox1 << std::endl;
             }
             
             static bool checkBox2 = true;
-            color.red.val -= 100; color.green.val += 100; color.blue.val += 100;
+            color = color - 100_r + 100_g + 100_b;
             rect.y -= 100; rect.width = rect.height = 50;
             if(gui.ctx.checkbox(rect, color, checkBox2)) {
                 std::cout << "Checkbox 2: new value " << checkBox2 << std::endl;

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -99,21 +99,21 @@ public:
             gui.ctx.start_window(fpsString.c_str(), winX, winY);
             for(int i = 0; i < 4; ++i) {
                 rect.x -= 10; rect.y = 40 * i;
-                color.red() += 25; color.green() += 25;
+                color.red.val += 25; color.green.val += 25;
                 std::string title = "some  " + std::to_string(i + 1);
                 if(gui.ctx.button(title.c_str(), rect, color)) {
                     std::cout << "Button " << (i + 1) << ": pressed" << std::endl;
                 }
             }
             
-            color.green() += 50;
+            color.green.val += 50;
             rect.y += 40; rect.width += 50;
             static float sliderValue0 = 20;
             if(gui.ctx.slider(rect, color, sliderValue0, 20, 40, 5)) {
                 std::cout << "Slider 1: new value " << sliderValue0 << std::endl;
             }
             
-            color.green() += 50;
+            color.green.val += 50;
             rect.y += 40;
             rect.width += 50;
             
@@ -133,14 +133,14 @@ public:
             }
             
             static bool checkBox1 = false;
-            color.red() += 15; color.green() -= 35; color.blue() -= 10;
+            color.red.val += 15; color.green.val -= 35; color.blue.val -= 10;
             rect.x += 270; rect.width = 40; rect.height = 20;
             if(gui.ctx.checkbox(rect, color, checkBox1)) {
                 std::cout << "Checkbox 1: new value " << checkBox1 << std::endl;
             }
             
             static bool checkBox2 = true;
-            color.red() -= 100; color.green() += 100; color.blue() += 100;
+            color.red.val -= 100; color.green.val += 100; color.blue.val += 100;
             rect.y -= 100; rect.width = rect.height = 50;
             if(gui.ctx.checkbox(rect, color, checkBox2)) {
                 std::cout << "Checkbox 2: new value " << checkBox2 << std::endl;

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -90,8 +90,10 @@ public:
             if(quit) break;
             
             // ================== GUI setup =================
+            using namespace reig::Colors::literals;
+
             reig::Rectangle rect {40, 0, 100, 30};
-            reig::Color color {120, 100, 150};
+            reig::Color color {120_r, 100_g, 150_b};
             
             static float winX = 10, winY = 10;
             gui.ctx.start_window(fpsString.c_str(), winX, winY);
@@ -124,7 +126,7 @@ public:
             rect.y += 40; rect.width += 50; rect.height += 10;
             if(gui.ctx.slider(
                 rect, 
-                reig::Color(220, 200, 150),
+                reig::Color(220_r, 200_g, 150_b),
                 sliderValue2, 0.1f, 0.5f, 0.05f
             )) {
                 std::cout << "Slider 2: new value " << sliderValue2 << std::endl;

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -49,15 +49,15 @@ namespace reig::detail {
     }
 
     Color get_yiq_contrast(Color color) {
-        uint_t y = (299u * color.red + 587 * color.green + 114 * color.blue) / 1000;
-        return y >= 128 ? Color{0u, 0u, 0u} : Color{255u, 255u, 255u};
+        uint_t y = (299u * color.red() + 587 * color.green() + 114 * color.blue()) / 1000;
+        return y >= 128 ? Color{0, 0, 0} : Color{255u, 255u, 255u};
     }
 
     Color lighten_color_by(Color color, ubyte_t delta) {
         ubyte_t max = 255u;
-        color.red < max - delta ? color.red += delta : color.red = max;
-        color.green < max - delta ? color.green += delta : color.green = max;
-        color.blue < max - delta ? color.blue += delta : color.blue = max;
+        color.red() < max - delta ? color.red() += delta : color.red() = max;
+        color.green() < max - delta ? color.green()+= delta : color.green() = max;
+        color.blue() < max - delta ? color.blue() += delta : color.blue() = max;
         return color;
     }
 
@@ -72,10 +72,10 @@ namespace reig::detail {
 }
 
 auto reig::Colors::to_uint(Color const& color) -> uint_t {
-    return (color.alpha << 24)
-           + (color.blue << 16)
-           + (color.green << 8)
-           + color.red;
+    return (color.alpha() << 24)
+           + (color.blue() << 16)
+           + (color.green() << 8)
+           + color.red();
 }
 
 auto reig::Colors::from_uint(uint_t rgba) -> Color {
@@ -83,13 +83,13 @@ auto reig::Colors::from_uint(uint_t rgba) -> Color {
             static_cast<ubyte_t>((rgba >> 24) & 0xFF),
             static_cast<ubyte_t>((rgba >> 16) & 0xFF),
             static_cast<ubyte_t>((rgba >> 8) & 0xFF),
-            static_cast<ubyte_t>(rgba & 0xFF),
+            static_cast<ubyte_t>(rgba & 0xFF)
     };
 }
 
 auto reig::Colors::with_alpha(Color const &from, ubyte_t alpha) -> Color {
     Color ret = from;
-    ret.alpha = alpha;
+    ret.alpha() = alpha;
     return ret;
 }
 

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -113,6 +113,54 @@ auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> C
     return ret;
 }
 
+auto reig::Colors::mixing::operator+(Color const& left, Red const& right) -> Color {
+    Color ret = left;
+    ret.red.val += right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator+(Color const& left, Green const& right) -> Color {
+    Color ret = left;
+    ret.green.val += right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator+(Color const& left, Blue const& right) -> Color {
+    Color ret = left;
+    ret.blue.val += right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator+(Color const& left, Alpha const& right) -> Color {
+    Color ret = left;
+    ret.alpha.val += right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator-(Color const& left, Red const& right) -> Color {
+    Color ret = left;
+    ret.red.val -= right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator-(Color const& left, Green const& right) -> Color {
+    Color ret = left;
+    ret.green.val -= right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator-(Color const& left, Blue const& right) -> Color {
+    Color ret = left;
+    ret.blue.val -= right.val;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator-(Color const& left, Alpha const& right) -> Color {
+    Color ret = left;
+    ret.alpha.val -= right.val;
+    return ret;
+}
+
 auto reig::Colors::to_uint(Color const& color) -> uint_t {
     return (color.alpha.val << 24)
            + (color.blue.val << 16)

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -71,6 +71,12 @@ namespace reig::detail {
     }
 }
 
+auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> Color {
+    Color ret = left;
+    ret.alpha() = right.val;
+    return ret;
+}
+
 auto reig::Colors::to_uint(Color const& color) -> uint_t {
     return (color.alpha() << 24)
            + (color.blue() << 16)
@@ -85,12 +91,6 @@ auto reig::Colors::from_uint(uint_t rgba) -> Color {
             static_cast<ubyte_t>((rgba >> 8) & 0xFF),
             static_cast<ubyte_t>(rgba & 0xFF)
     };
-}
-
-auto reig::Colors::with_alpha(Color const &from, ubyte_t alpha) -> Color {
-    Color ret = from;
-    ret.alpha() = alpha;
-    return ret;
 }
 
 void reig::Context::set_render_handler(RenderHandler renderHandler) {
@@ -273,10 +273,12 @@ void reig::Context::end_window() {
             mCurrentWindow.w, mCurrentWindow.h - mCurrentWindow.headerSize
     };
 
-    render_rectangle(headerBox, Colors::with_alpha(Colors::mediumGrey, 200));
+    using namespace Colors::mixing;
+
+    render_rectangle(headerBox, Colors::mediumGrey | Alpha{200});
     render_triangle(headerTriangle, Colors::lightGrey);
     render_text(mCurrentWindow.title, titleBox);
-    render_rectangle(bodyBox, Colors::with_alpha(Colors::mediumGrey, 100));
+    render_rectangle(bodyBox, Colors::mediumGrey | Alpha{100});
 
     if(mouse.leftButton.mIsPressed && detail::in_box(mouse.leftButton.mClickedPos, headerBox)) {
         Point moved{

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -49,8 +49,10 @@ namespace reig::detail {
     }
 
     Color get_yiq_contrast(Color color) {
+        using namespace Colors::literals;
+
         uint_t y = (299u * color.red() + 587 * color.green() + 114 * color.blue()) / 1000;
-        return y >= 128 ? Color{0, 0, 0} : Color{255u, 255u, 255u};
+        return y >= 128 ? Color{0_r, 0_g, 0_b} : Color{255_r, 255_g, 255_b};
     }
 
     Color lighten_color_by(Color color, ubyte_t delta) {
@@ -71,8 +73,20 @@ namespace reig::detail {
     }
 }
 
-auto reig::Colors::literals::operator ""_a(unsigned long long alpha) -> Alpha {
-    return Alpha{static_cast<ubyte_t>(alpha)};
+auto reig::Colors::literals::operator ""_r(unsigned long long val) -> Red {
+    return Red{static_cast<ubyte_t>(val)};
+}
+
+auto reig::Colors::literals::operator ""_g(unsigned long long val) -> Green {
+    return Green{static_cast<ubyte_t>(val)};
+}
+
+auto reig::Colors::literals::operator ""_b(unsigned long long val) -> Blue {
+    return Blue{static_cast<ubyte_t>(val)};
+}
+
+auto reig::Colors::literals::operator ""_a(unsigned long long val) -> Alpha {
+    return Alpha{static_cast<ubyte_t>(val)};
 }
 
 auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> Color {
@@ -90,10 +104,10 @@ auto reig::Colors::to_uint(Color const& color) -> uint_t {
 
 auto reig::Colors::from_uint(uint_t rgba) -> Color {
     return Color {
-            static_cast<ubyte_t>((rgba >> 24) & 0xFF),
-            static_cast<ubyte_t>((rgba >> 16) & 0xFF),
-            static_cast<ubyte_t>((rgba >> 8) & 0xFF),
-            static_cast<ubyte_t>(rgba & 0xFF)
+            Red{static_cast<ubyte_t>((rgba >> 24) & 0xFF)},
+            Green{static_cast<ubyte_t>((rgba >> 16) & 0xFF)},
+            Blue{static_cast<ubyte_t>((rgba >> 8) & 0xFF)},
+            Alpha{static_cast<ubyte_t>(rgba & 0xFF)}
     };
 }
 

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -71,6 +71,10 @@ namespace reig::detail {
     }
 }
 
+auto reig::Colors::literals::operator ""_a(unsigned long long alpha) -> Alpha {
+    return Alpha{static_cast<ubyte_t>(alpha)};
+}
+
 auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> Color {
     Color ret = left;
     ret.alpha() = right.val;
@@ -273,12 +277,13 @@ void reig::Context::end_window() {
             mCurrentWindow.w, mCurrentWindow.h - mCurrentWindow.headerSize
     };
 
+    using namespace Colors::literals;
     using namespace Colors::mixing;
 
-    render_rectangle(headerBox, Colors::mediumGrey | Alpha{200});
+    render_rectangle(headerBox, Colors::mediumGrey | 200_a);
     render_triangle(headerTriangle, Colors::lightGrey);
     render_text(mCurrentWindow.title, titleBox);
-    render_rectangle(bodyBox, Colors::mediumGrey | Alpha{100});
+    render_rectangle(bodyBox, Colors::mediumGrey | 100_a);
 
     if(mouse.leftButton.mIsPressed && detail::in_box(mouse.leftButton.mClickedPos, headerBox)) {
         Point moved{

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -89,6 +89,24 @@ auto reig::Colors::literals::operator ""_a(unsigned long long val) -> Alpha {
     return Alpha{static_cast<ubyte_t>(val)};
 }
 
+auto reig::Colors::mixing::operator|(Color const& left, Red const& right) -> Color {
+    Color ret = left;
+    ret.red = right;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator|(Color const& left, Green const& right) -> Color {
+    Color ret = left;
+    ret.green = right;
+    return ret;
+}
+
+auto reig::Colors::mixing::operator|(Color const& left, Blue const& right) -> Color {
+    Color ret = left;
+    ret.blue = right;
+    return ret;
+}
+
 auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> Color {
     Color ret = left;
     ret.alpha = right;

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -51,15 +51,15 @@ namespace reig::detail {
     Color get_yiq_contrast(Color color) {
         using namespace Colors::literals;
 
-        uint_t y = (299u * color.red() + 587 * color.green() + 114 * color.blue()) / 1000;
+        uint_t y = (299u * color.red.val + 587 * color.green.val + 114 * color.blue.val) / 1000;
         return y >= 128 ? Color{0_r, 0_g, 0_b} : Color{255_r, 255_g, 255_b};
     }
 
     Color lighten_color_by(Color color, ubyte_t delta) {
         ubyte_t max = 255u;
-        color.red() < max - delta ? color.red() += delta : color.red() = max;
-        color.green() < max - delta ? color.green()+= delta : color.green() = max;
-        color.blue() < max - delta ? color.blue() += delta : color.blue() = max;
+        color.red.val < max - delta ? color.red.val += delta : color.red.val = max;
+        color.green.val < max - delta ? color.green.val += delta : color.green.val = max;
+        color.blue.val < max - delta ? color.blue.val += delta : color.blue.val = max;
         return color;
     }
 
@@ -91,15 +91,15 @@ auto reig::Colors::literals::operator ""_a(unsigned long long val) -> Alpha {
 
 auto reig::Colors::mixing::operator|(Color const& left, Alpha const& right) -> Color {
     Color ret = left;
-    ret.alpha() = right.val;
+    ret.alpha = right;
     return ret;
 }
 
 auto reig::Colors::to_uint(Color const& color) -> uint_t {
-    return (color.alpha() << 24)
-           + (color.blue() << 16)
-           + (color.green() << 8)
-           + color.red();
+    return (color.alpha.val << 24)
+           + (color.blue.val << 16)
+           + (color.green.val << 8)
+           + color.red.val;
 }
 
 auto reig::Colors::from_uint(uint_t rgba) -> Color {

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -84,6 +84,16 @@ namespace reig {
             Color operator|(Color const& left, Green const& right);
             Color operator|(Color const& left, Blue const& right);
             Color operator|(Color const& left, Alpha const& right);
+
+            Color operator+(Color const& left, Red const& right);
+            Color operator+(Color const& left, Green const& right);
+            Color operator+(Color const& left, Blue const& right);
+            Color operator+(Color const& left, Alpha const& right);
+
+            Color operator-(Color const& left, Red const& right);
+            Color operator-(Color const& left, Green const& right);
+            Color operator-(Color const& left, Blue const& right);
+            Color operator-(Color const& left, Alpha const& right);
         }
 
         #pragma clang diagnostic push

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -55,30 +55,16 @@ namespace reig {
         constexpr explicit Alpha(ubyte_t val = 0xFFu) : val{val} {}
     };
 
-    class Color {
-    public:
+    struct Color {
         constexpr Color() = default;
 
         constexpr Color(Red const& red, Green const& green, Blue const& blue, Alpha const& alpha = Alpha{0xFFu}) noexcept
-                : mRed{red}, mGreen{green}, mBlue{blue}, mAlpha{alpha} {}
+                : red{red}, green{green}, blue{blue}, alpha{alpha} {}
 
-        ubyte_t& red() { return mRed.val; }
-        ubyte_t const& red() const { return mRed.val; }
-
-        ubyte_t& green() { return mGreen.val; }
-        ubyte_t const& green() const { return mGreen.val; }
-
-        ubyte_t& blue() { return mBlue.val; }
-        ubyte_t const& blue() const { return mBlue.val; }
-
-        ubyte_t& alpha() { return mAlpha.val; }
-        ubyte_t const& alpha() const { return mAlpha.val; }
-
-    private:
-        Red mRed;
-        Green mGreen;
-        Blue mBlue;
-        Alpha mAlpha;
+        Red red;
+        Green green;
+        Blue blue;
+        Alpha alpha;
     };
 
     namespace Colors {

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -59,9 +59,6 @@ namespace reig {
     public:
         constexpr Color() = default;
 
-        constexpr Color(ubyte_t red, ubyte_t green, ubyte_t blue, ubyte_t alpha = 0xFFu) noexcept
-                : Color{Red{red}, Green{green}, Blue{blue}, Alpha{alpha}} {}
-
         constexpr Color(Red const& red, Green const& green, Blue const& blue, Alpha const& alpha = Alpha{0xFFu}) noexcept
                 : mRed{red}, mGreen{green}, mBlue{blue}, mAlpha{alpha} {}
 
@@ -90,6 +87,9 @@ namespace reig {
         Color from_uint(uint_t rgba);
 
         namespace literals {
+            Red operator""_r(unsigned long long alpha);
+            Green operator""_g(unsigned long long alpha);
+            Blue operator""_b(unsigned long long alpha);
             Alpha operator""_a(unsigned long long alpha);
         }
 

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -89,7 +89,9 @@ namespace reig {
 
         Color from_uint(uint_t rgba);
 
-        Color with_alpha(Color const& from, ubyte_t alpha);
+        namespace mixing {
+            Color operator|(Color const& left, Alpha const& right);
+        }
 
         #pragma clang diagnostic push
         #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -31,15 +31,57 @@ namespace reig {
         Point pos2;
     };
 
-    struct Color {
-        constexpr Color() = default;
-        constexpr Color(ubyte_t red, ubyte_t green, ubyte_t blue, ubyte_t alpha = 0xFFu) noexcept
-                : red{red}, green{green}, blue{blue}, alpha{alpha} {}
+    struct Red {
+        ubyte_t val = 0u;
 
-        ubyte_t red   = 0u;
-        ubyte_t green = 0u;
-        ubyte_t blue  = 0u;
-        ubyte_t alpha = 0xFFu;
+        constexpr explicit Red(ubyte_t val = 0u) : val{val} {}
+    };
+
+    struct Green {
+        ubyte_t val = 0u;
+
+        constexpr explicit Green(ubyte_t val = 0u) : val{val} {}
+    };
+
+    struct Blue {
+        ubyte_t val = 0u;
+
+        constexpr explicit Blue(ubyte_t val = 0u) : val{val} {}
+    };
+
+    struct Alpha {
+        ubyte_t val = 0xFFu;
+
+        constexpr explicit Alpha(ubyte_t val = 0xFFu) : val{val} {}
+    };
+
+    class Color {
+    public:
+        constexpr Color() = default;
+
+        constexpr Color(ubyte_t red, ubyte_t green, ubyte_t blue, ubyte_t alpha = 0xFFu) noexcept
+                : Color{Red{red}, Green{green}, Blue{blue}, Alpha{alpha}} {}
+
+        constexpr Color(Red const& red, Green const& green, Blue const& blue, Alpha const& alpha = Alpha{0xFFu}) noexcept
+                : mRed{red}, mGreen{green}, mBlue{blue}, mAlpha{alpha} {}
+
+        ubyte_t& red() { return mRed.val; }
+        ubyte_t const& red() const { return mRed.val; }
+
+        ubyte_t& green() { return mGreen.val; }
+        ubyte_t const& green() const { return mGreen.val; }
+
+        ubyte_t& blue() { return mBlue.val; }
+        ubyte_t const& blue() const { return mBlue.val; }
+
+        ubyte_t& alpha() { return mAlpha.val; }
+        ubyte_t const& alpha() const { return mAlpha.val; }
+
+    private:
+        Red mRed;
+        Green mGreen;
+        Blue mBlue;
+        Alpha mAlpha;
     };
 
     namespace Colors {
@@ -47,23 +89,23 @@ namespace reig {
 
         Color from_uint(uint_t rgba);
 
-        Color with_alpha(Color const &from, ubyte_t alpha);
+        Color with_alpha(Color const& from, ubyte_t alpha);
 
         #pragma clang diagnostic push
         #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
-        Color constexpr transparent{0, 0, 0, 0};
-        Color constexpr red{239, 41, 41};
-        Color constexpr orange{252, 175, 62};
-        Color constexpr yellow{252, 233, 79};
-        Color constexpr green{138, 226, 52};
-        Color constexpr blue{114, 159, 207};
-        Color constexpr violet{173, 127, 168};
-        Color constexpr brown{143, 89, 2};
-        Color constexpr white{255, 255, 255};
-        Color constexpr lightGrey{186, 189, 182};
-        Color constexpr mediumGrey{136, 138, 133};
-        Color constexpr darkGrey{46, 52, 54};
-        Color constexpr black{0, 0, 0};
+        Color constexpr transparent{Red{}, Green{}, Blue{}, Alpha{}};
+        Color constexpr red{Red{239}, Green{41}, Blue{41}};;
+        Color constexpr orange{Red{252}, Green{175}, Blue{62}};;
+        Color constexpr yellow{Red{252}, Green{233}, Blue{79}};;
+        Color constexpr green{Red{138}, Green{226}, Blue{52}};;
+        Color constexpr blue{Red{114}, Green{159}, Blue{207}};;
+        Color constexpr violet{Red{173}, Green{127}, Blue{168}};;
+        Color constexpr brown{Red{143}, Green{89}, Blue{2}};;
+        Color constexpr white{Red{255}, Green{255}, Blue{255}};;
+        Color constexpr lightGrey{Red{186}, Green{189}, Blue{182}};;
+        Color constexpr mediumGrey{Red{136}, Green{138}, Blue{133}};;
+        Color constexpr darkGrey{Red{46}, Green{52}, Blue{54}};;
+        Color constexpr black{Red{0}, Green{0}, Blue{0}};;
         #pragma clang diagnostic pop
     }
 
@@ -206,10 +248,10 @@ namespace reig {
     namespace detail {
         struct Font {
             stbtt_bakedchar* bakedChars = nullptr;
-            float size   = 0.f;
+            float size = 0.f;
             uint_t texture = 0;
-            uint_t width   = 0;
-            uint_t height  = 0;
+            uint_t width = 0;
+            uint_t height = 0;
         };
 
         struct Window {
@@ -281,6 +323,7 @@ namespace reig {
 
         // Widget renders
         void start_window(char const* title, float& x, float& y);
+
         void end_window();
 
         /**
@@ -372,6 +415,7 @@ namespace reig {
          * @param box Text's bounding box
          */
         void render_text(char const* text, Rectangle box);
+
         /**
          * @brief Schedules a rectangle drawing
          * @param rect Position and size
@@ -392,6 +436,7 @@ namespace reig {
          * @param color Color
          */
         void render_triangle(Triangle const& triangle, Color const& color);
+
     private:
         std::vector<Figure> mDrawData;
         detail::Font mFont;

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -89,6 +89,10 @@ namespace reig {
 
         Color from_uint(uint_t rgba);
 
+        namespace literals {
+            Alpha operator""_a(unsigned long long alpha);
+        }
+
         namespace mixing {
             Color operator|(Color const& left, Alpha const& right);
         }

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -80,6 +80,9 @@ namespace reig {
         }
 
         namespace mixing {
+            Color operator|(Color const& left, Red const& right);
+            Color operator|(Color const& left, Green const& right);
+            Color operator|(Color const& left, Blue const& right);
             Color operator|(Color const& left, Alpha const& right);
         }
 


### PR DESCRIPTION
Make color components strongly typed instead of `ubyte_t`.
Add `_r`, `_g`, `_b`, `_a` literals for ease of declaring.
Add `|` for ease of creating copy of colors with some components altered.
Add `+`\\`-` for ease of creating copy of colors with components incremented\decremented.