### PR TITLE
Use `detail` namespace in headers, `internal` in implementations

### DIFF
--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -99,7 +99,7 @@ public:
             
             // ================== GUI setup =================
             using namespace reig::Colors::literals;
-            using namespace reig::Colors::mixing;
+            using namespace reig::Colors::operators;
 
             reig::Rectangle rect {40, 0, 100, 30};
             reig::Color color {120_r, 100_g, 150_b};

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -358,7 +358,7 @@ void reig::Context::end_window() {
     }
 }
 
-void reig::detail::Window::expand(Rectangle& aBox) {
+void reig::context::Window::expand(Rectangle& aBox) {
     if (started) {
         aBox.x += *x + 4;
         aBox.y += *y + headerSize + 4;

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -358,7 +358,7 @@ void reig::Context::end_window() {
     }
 }
 
-void reig::context::Window::expand(Rectangle& aBox) {
+void reig::detail::Window::expand(Rectangle& aBox) {
     if (started) {
         aBox.x += *x + 4;
         aBox.y += *y + headerSize + 4;

--- a/lib/reig.cpp
+++ b/lib/reig.cpp
@@ -338,7 +338,7 @@ void reig::Context::end_window() {
     };
 
     using namespace Colors::literals;
-    using namespace Colors::mixing;
+    using namespace Colors::operators;
 
     render_rectangle(headerBox, Colors::mediumGrey | 200_a);
     render_triangle(headerTriangle, Colors::lightGrey);

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -93,7 +93,7 @@ namespace reig {
             }
         }
 
-        namespace mixing {
+        namespace operators {
             namespace detail {
                 template<typename Comp>
                 static constexpr bool is_color_component_v = std::is_same_v<Comp, Red> ||

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -294,7 +294,7 @@ namespace reig {
         uint_t height = 0;
     };
 
-    namespace context {
+    namespace detail {
         struct Font {
             std::vector<stbtt_bakedchar> bakedChars;
             float size = 0.f;
@@ -556,8 +556,8 @@ namespace reig {
 
     private:
         std::vector<Figure> mDrawData;
-        context::Font mFont;
-        context::Window mCurrentWindow;
+        detail::Font mFont;
+        detail::Window mCurrentWindow;
 
         RenderHandler mRenderHandler = nullptr;
         std::any mUserPtr;

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -294,7 +294,7 @@ namespace reig {
         uint_t height = 0;
     };
 
-    namespace detail {
+    namespace context {
         struct Font {
             std::vector<stbtt_bakedchar> bakedChars;
             float size = 0.f;
@@ -556,8 +556,8 @@ namespace reig {
 
     private:
         std::vector<Figure> mDrawData;
-        detail::Font mFont;
-        detail::Window mCurrentWindow;
+        context::Font mFont;
+        context::Window mCurrentWindow;
 
         RenderHandler mRenderHandler = nullptr;
         std::any mUserPtr;

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -94,7 +94,7 @@ namespace reig {
         }
 
         namespace operators {
-            namespace detail {
+            namespace meta {
                 template<typename Comp>
                 static constexpr bool is_color_component_v = std::is_same_v<Comp, Red> ||
                                                              std::is_same_v<Comp, Green> ||
@@ -118,24 +118,24 @@ namespace reig {
                 }
             }
 
-            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
             Color operator|(Color const& left, Comp const& right) {
                 Color ret = left;
-                detail::get_comp<Comp>(ret) = right;
+                meta::get_comp<Comp>(ret) = right;
                 return ret;
             };
 
-            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
             Color operator+(Color const& left, Comp const& right) {
                 Color ret = left;
-                detail::get_comp<Comp>(ret).val += right.val;
+                meta::get_comp<Comp>(ret).val += right.val;
                 return ret;
             };
 
-            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
             Color operator-(Color const& left, Comp const& right) {
                 Color ret = left;
-                detail::get_comp<Comp>(ret).val -= right.val;
+                meta::get_comp<Comp>(ret).val -= right.val;
                 return ret;
             };
         }

--- a/lib/reig.h
+++ b/lib/reig.h
@@ -94,7 +94,7 @@ namespace reig {
         }
 
         namespace operators {
-            namespace meta {
+            namespace detail {
                 template<typename Comp>
                 static constexpr bool is_color_component_v = std::is_same_v<Comp, Red> ||
                                                              std::is_same_v<Comp, Green> ||
@@ -118,24 +118,24 @@ namespace reig {
                 }
             }
 
-            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
             Color operator|(Color const& left, Comp const& right) {
                 Color ret = left;
-                meta::get_comp<Comp>(ret) = right;
+                detail::get_comp<Comp>(ret) = right;
                 return ret;
             };
 
-            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
             Color operator+(Color const& left, Comp const& right) {
                 Color ret = left;
-                meta::get_comp<Comp>(ret).val += right.val;
+                detail::get_comp<Comp>(ret).val += right.val;
                 return ret;
             };
 
-            template<typename Comp, typename = std::enable_if_t<meta::is_color_component_v<Comp>>>
+            template<typename Comp, typename = std::enable_if_t<detail::is_color_component_v<Comp>>>
             Color operator-(Color const& left, Comp const& right) {
                 Color ret = left;
-                meta::get_comp<Comp>(ret).val -= right.val;
+                detail::get_comp<Comp>(ret).val -= right.val;
                 return ret;
             };
         }


### PR DESCRIPTION
So the changes are:  
- `detail` namespace from cpp was renamed to `internal`.  
- `mixing` was named `operators`

closes #22 