### PR TITLE
Add list widgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(reig_lib
         lib/reig/exception.h lib/reig/exception.cpp
         lib/reig/reference_widget.h lib/reig/reference_widget.cpp
         lib/reig/internal.h lib/reig/internal.cpp
-        lib/reig/context.h lib/reig/context.cpp lib/reig/reference_widget_list.h)
+        lib/reig/context.h lib/reig/context.cpp lib/reig/reference_widget_list.h lib/reig/reference_widget_list.cpp)
 add_library(my::reig_lib ALIAS reig_lib)
 target_compile_features(reig_lib
         PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ add_library(reig_lib
         lib/reig/exception.h lib/reig/exception.cpp
         lib/reig/reference_widget.h lib/reig/reference_widget.cpp
         lib/reig/internal.h lib/reig/internal.cpp
-        lib/reig/context.h lib/reig/context.cpp lib/reig/reference_widget_list.h lib/reig/reference_widget_list.cpp)
+        lib/reig/context.h lib/reig/context.cpp
+        lib/reig/reference_widget_list.h lib/reig/reference_widget_list.cpp
+        )
 add_library(my::reig_lib ALIAS reig_lib)
 target_compile_features(reig_lib
         PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(reig_lib
         lib/reig/exception.h lib/reig/exception.cpp
         lib/reig/reference_widget.h lib/reig/reference_widget.cpp
         lib/reig/internal.h lib/reig/internal.cpp
-        lib/reig/context.h lib/reig/context.cpp)
+        lib/reig/context.h lib/reig/context.cpp lib/reig/reference_widget_list.h)
 add_library(my::reig_lib ALIAS reig_lib)
 target_compile_features(reig_lib
         PUBLIC

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -172,16 +172,17 @@ public:
             gui.ctx.enqueue(widget::scrollbar{rect, primitive::colors::black, scroll1, 1000.0f});
 
             struct Foo {
-                const char* name = "";
+                const std::string name;
             };
             static std::vector<Foo> foos {
-                    {"One"}, {"Two"}, {"Three"}, {"Four"}
+                    {"Zero"}, {"One"}, {"Two"}, {"Three"}, {"Four"}, {"Five"},
+                    {"Six"}, {"Seven"}, {"Eight"}, {"Nine"}, {"Ten"}
             };
             rect.y = 5; rect.x += 370; rect.height = 280;
             gui.ctx.enqueue(widget::list(
                     "Test", rect, primitive::colors::violet,
                     std::begin(foos), std::end(foos), [](const Foo& foo) {
-                        return foo.name;
+                        return foo.name.c_str();
                     },
                     [](int position, const Foo& foo) {
                         std::cout << "Clicked on " << position << "th foo: " << foo.name << '\n';

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -183,7 +183,7 @@ public:
             };
             gui.ctx.enqueue(widget::list(
                     "Test", rect, colors::violet,
-                    std::begin(foos), std::end(foos), [](const Foo& foo) {
+                    foos, [](const Foo& foo) {
                         return foo.name.c_str();
                     },
                     [](int position, const Foo& foo) {

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -182,7 +182,7 @@ public:
                     {"Six"}, {"Seven"}, {"Eight"}, {"Nine"}, {"Ten"}
             };
             gui.ctx.enqueue(widget::list(
-                    "Test", rect, colors::violet, foos,
+                    "Test", rect, colors::blue, foos,
                     [](const Foo& foo) {
                         return foo.name.c_str();
                     },

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -182,8 +182,8 @@ public:
                     {"Six"}, {"Seven"}, {"Eight"}, {"Nine"}, {"Ten"}
             };
             gui.ctx.enqueue(widget::list(
-                    "Test", rect, colors::violet,
-                    foos, [](const Foo& foo) {
+                    "Test", rect, colors::violet, foos,
+                    [](const Foo& foo) {
                         return foo.name.c_str();
                     },
                     [](int position, const Foo& foo) {

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -104,6 +104,7 @@ public:
             using namespace reig::primitive::colors::operators;
             namespace widget = reig::reference_widget;
             namespace primitive = reig::primitive;
+            namespace colors = reig::primitive::colors;
 
             primitive::Rectangle rect {40, 0, 100, 30};
             primitive::Color color {120_r, 100_g, 150_b};
@@ -156,7 +157,7 @@ public:
             }
 
             static bool checkBox3 = false;
-            color = primitive::colors::from_uint(0xFFFFFFFFu);
+            color = colors::from_uint(0xFFFFFFFFu);
             rect.y += 60; rect.width = rect.height = 25;
             if(gui.ctx.enqueue(widget::checkbox{rect, color, checkBox3})) {
                 std::cout << "Checkbox 3: new value " << checkBox3 << std::endl;
@@ -164,12 +165,14 @@ public:
 
             static float scroll1 = 0.0f;
             rect.x += 60; rect.y = 5; rect.width = 30; rect.height = 280;
-            if(gui.ctx.enqueue(widget::scrollbar{rect, primitive::colors::black, scroll1, 1000.0f})) {
+            if(gui.ctx.enqueue(widget::scrollbar{rect, colors::black, scroll1, 1000.0f})) {
                 std::cout << "Scrolled: " << scroll1 << '\n';
             }
 
             rect.x = 5; rect.y += 300; rect.width = 280; rect.height = 30;
-            gui.ctx.enqueue(widget::scrollbar{rect, primitive::colors::black, scroll1, 1000.0f});
+            gui.ctx.enqueue(widget::scrollbar{rect, colors::black, scroll1, 1000.0f});
+
+            rect.y = 5; rect.x += 370; rect.height = 280;
 
             struct Foo {
                 const std::string name;
@@ -178,9 +181,8 @@ public:
                     {"Zero"}, {"One"}, {"Two"}, {"Three"}, {"Four"}, {"Five"},
                     {"Six"}, {"Seven"}, {"Eight"}, {"Nine"}, {"Ten"}
             };
-            rect.y = 5; rect.x += 370; rect.height = 280;
             gui.ctx.enqueue(widget::list(
-                    "Test", rect, primitive::colors::violet,
+                    "Test", rect, colors::violet,
                     std::begin(foos), std::end(foos), [](const Foo& foo) {
                         return foo.name.c_str();
                     },

--- a/lib/reig/internal.cpp
+++ b/lib/reig/internal.cpp
@@ -37,3 +37,20 @@ void reig::internal::render_widget_frame(reig::Context& ctx, Rectangle& bounding
     boundingBox = internal::decrease_box(boundingBox, 4);
     ctx.render_rectangle(boundingBox, baseColor);
 }
+
+void reig::internal::fit_rect_in_other(Rectangle& fitted, const Rectangle& container) {
+    fitted.x = max(fitted.x, container.x);
+    fitted.y = max(fitted.y, container.y);
+
+    auto fit_size = [](float& fittedSize, const float& fittedCoord,
+                       const float& containerSize, const float& containerCoord) {
+        auto fittedEnd = fittedCoord + fittedSize;
+        auto containerEnd = containerCoord + containerSize;
+        auto end = min(fittedEnd, containerEnd);
+        auto excess = fittedEnd - end;
+        fittedSize -= excess;
+    };
+
+    fit_size(fitted.width, fitted.x, container.width, container.x);
+    fit_size(fitted.height, fitted.y, container.height, container.y);
+}

--- a/lib/reig/internal.cpp
+++ b/lib/reig/internal.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "context.h"
 
 bool reig::internal::is_boxed_in(Point const& pt, Rectangle const& box) {
     return is_between(pt.x, box.x, box.x + box.width) && is_between(pt.y, box.y, box.y + box.height);
@@ -28,4 +29,11 @@ Rectangle reig::internal::decrease_box(Rectangle aRect, int by) {
     aRect.width -= by;
     aRect.height -= by;
     return aRect;
+}
+
+void reig::internal::render_widget_frame(reig::Context& ctx, Rectangle& boundingBox, Color const& baseColor) {
+    Color frameColor = internal::get_yiq_contrast(baseColor);
+    ctx.render_rectangle(boundingBox, frameColor);
+    boundingBox = internal::decrease_box(boundingBox, 4);
+    ctx.render_rectangle(boundingBox, baseColor);
 }

--- a/lib/reig/internal.h
+++ b/lib/reig/internal.h
@@ -59,6 +59,8 @@ namespace reig::internal {
         }
         return r;
     };
+
+    void render_widget_frame(Context& ctx, Rectangle& boundingBox, Color const& baseColor);
 }
 
 #endif //REIG_INTERNAL_H

--- a/lib/reig/internal.h
+++ b/lib/reig/internal.h
@@ -61,6 +61,8 @@ namespace reig::internal {
     };
 
     void render_widget_frame(Context& ctx, Rectangle& boundingBox, Color const& baseColor);
+
+    void fit_rect_in_other(Rectangle& fitted, const Rectangle& container);
 }
 
 #endif //REIG_INTERNAL_H

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -62,13 +62,6 @@ void reig::reference_widget::label::draw(reig::Context& ctx) const {
     ctx.render_text(mTitle, boundingBox);
 }
 
-void render_widget_frame(reig::Context& ctx, Rectangle& boundingBox, Color const& baseColor) {
-    Color frameColor = internal::get_yiq_contrast(baseColor);
-    ctx.render_rectangle(boundingBox, frameColor);
-    boundingBox = internal::decrease_box(boundingBox, 4);
-    ctx.render_rectangle(boundingBox, baseColor);
-}
-
 struct SliderValues {
     float min = 0.0f;
     float max = 0.0f;
@@ -118,7 +111,7 @@ bool reig::reference_widget::slider::draw(reig::Context& ctx) const {
     Rectangle boundingBox = {mBoundingBox};
     ctx.fit_rect_in_window(boundingBox);
 
-    render_widget_frame(ctx, boundingBox, mBaseColor);
+    internal::render_widget_frame(ctx, boundingBox, mBaseColor);
 
     auto [min, max, value, offset, valuesNum] = prepare_slider_values(mMin, mMax, mValueRef, mStep);
 
@@ -168,7 +161,7 @@ bool reig::reference_widget::scrollbar::draw(reig::Context& ctx) const {
     Rectangle boundingBox = {mBoundingBox};
     ctx.fit_rect_in_window(boundingBox);
 
-    render_widget_frame(ctx, boundingBox, mBaseColor);
+    internal::render_widget_frame(ctx, boundingBox, mBaseColor);
 
     auto step = ctx.get_font_size() / 2.0f;
     auto [min, max, value, offset, valuesNum] = prepare_slider_values(0.0f, mViewSize - boundingBox.height, mValueRef, step);
@@ -250,7 +243,7 @@ bool reig::reference_widget::checkbox::draw(reig::Context& ctx) const {
     Rectangle boundingBox = this->mBoundingBox;
     ctx.fit_rect_in_window(boundingBox);
 
-    render_widget_frame(ctx, boundingBox, mBaseColor);
+    internal::render_widget_frame(ctx, boundingBox, mBaseColor);
 
     // Render check
     if (mValueRef) {

--- a/lib/reig/reference_widget_list.cpp
+++ b/lib/reig/reference_widget_list.cpp
@@ -1,0 +1,7 @@
+#include "reference_widget_list.h"
+#include <unordered_map>
+
+float& reig::reference_widget::detail::get_scroll_value(const char* title) {
+    static std::unordered_map<const char*, float> scrollValues;
+    return scrollValues[title];
+}

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -2,6 +2,7 @@
 #define REIG_REFERENCE_WIDGET_LIST_H
 
 #include "context.h"
+#include "internal.h"
 
 namespace reig::reference_widget {
     namespace detail {
@@ -41,11 +42,16 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
     ctx.render_rectangle(boundingBox, mBaseColor);
 
-    float fontHeight = ctx.get_font_height();
+    float fontHeight = ctx.get_font_size();
     float y = boundingBox.y;
     for(auto it = mBegin; it != mEnd; ++it) {
-        ctx.render_text(mAdapter(*it), {boundingBox.x, y, boundingBox.width, fontHeight});
+        Rectangle itemBox = {boundingBox.x, y, boundingBox.width, fontHeight};
+        ctx.render_text(mAdapter(*it), itemBox);
         y += fontHeight;
+
+        if(ctx.mouse.leftButton.is_clicked() && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox)) {
+            mAction(it - mBegin, *it);
+        }
     }
 }
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -41,6 +41,8 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
     float y = listBox.y;
     for (auto it = mBegin; it != mEnd && y < listBox.y + listBox.height; ++it, y += fontHeight) {
         Rectangle itemBox = {listBox.x, y, listBox.width, fontHeight};
+        internal::fit_rect_in_other(itemBox, listBox);
+
         auto is_in_bounds = [&](const Point& pt) {
             return internal::is_boxed_in(pt, itemBox)
                    && internal::is_boxed_in(pt, listBox);

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -20,17 +20,14 @@ namespace reig::reference_widget {
         };
     }
 
-    template <typename Iter, typename Adapter, typename Action>
-    detail::list<Iter, Adapter, Action>
-    list(const char* title,
-         const primitive::Rectangle& rectangle,
-         const primitive::Color& baseColor,
-         Iter&& begin,
-         Iter&& end,
-         Adapter&& adapter,
-         Action&& action
-    ) {
-        return {title, rectangle, baseColor, begin, end, adapter, action};
+    template <typename Range, typename Adapter, typename Action>
+    auto list(const char* title,
+              const primitive::Rectangle& rectangle,
+              const primitive::Color& baseColor,
+              Range&& range,
+              Adapter&& adapter,
+              Action&& action) -> detail::list<decltype(std::begin(range)), Adapter, Action> {
+        return {title, rectangle, baseColor, std::begin(range), std::end(range), adapter, action};
     };
 }
 
@@ -44,7 +41,7 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
     float fontHeight = ctx.get_font_size();
     float y = boundingBox.y;
-    for(auto it = mBegin; it != mEnd; ++it) {
+    for (auto it = mBegin; it != mEnd; ++it) {
         Rectangle itemBox = {boundingBox.x, y, boundingBox.width, fontHeight};
         ctx.render_text(mAdapter(*it), itemBox);
         y += fontHeight;

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -49,7 +49,9 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
         ctx.render_text(mAdapter(*it), itemBox);
         y += fontHeight;
 
-        if(ctx.mouse.leftButton.is_clicked() && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox)) {
+        if (ctx.mouse.leftButton.is_clicked()
+            && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox)
+            && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), boundingBox)) {
             mAction(it - mBegin, *it);
         }
     }

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -1,0 +1,45 @@
+#ifndef REIG_REFERENCE_WIDGET_LIST_H
+#define REIG_REFERENCE_WIDGET_LIST_H
+
+#include "context.h"
+
+namespace reig::reference_widget {
+    namespace detail {
+        template <typename Iter, typename Adapter, typename Action>
+        struct list {
+            const char* mTitle = "";
+            primitive::Rectangle mBoundingBox;
+            primitive::Color mBaseColor;
+            Iter mBegin;
+            Iter mEnd;
+            Adapter& adapter;
+            Action& action;
+
+            void draw(Context& ctx) const;
+        };
+    }
+
+    template <typename Iter, typename Adapter, typename Action>
+    detail::list<Iter, Adapter, Action>
+    list(const char* title,
+         const primitive::Rectangle& rectangle,
+         const primitive::Color& baseColor,
+         Iter&& begin,
+         Iter&& end,
+         Adapter&& adapter,
+         Action&& action
+    ) {
+        return {title, rectangle, baseColor, begin, end, adapter, action};
+    };
+}
+
+template <typename Iter, typename Adapter, typename Action>
+void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Context& ctx) const {
+    using namespace reig::primitive;
+    Rectangle boundingBox = {mBoundingBox};
+    ctx.fit_rect_in_window(boundingBox);
+
+    ctx.render_rectangle(boundingBox, mBaseColor);
+}
+
+#endif //REIG_REFERENCE_WIDGET_LIST_H

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -34,27 +34,32 @@ namespace reig::reference_widget {
 template <typename Iter, typename Adapter, typename Action>
 void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Context& ctx) const {
     using namespace reig::primitive;
-    Rectangle boundingBox = {mBoundingBox};
-    ctx.fit_rect_in_window(boundingBox);
+    Rectangle listBox = {mBoundingBox};
+    ctx.fit_rect_in_window(listBox);
 
     float fontHeight = ctx.get_font_size();
-    float y = boundingBox.y;
+    float y = listBox.y;
     for (auto it = mBegin; it != mEnd; ++it, y += fontHeight) {
-        Rectangle itemBox = {boundingBox.x, y, boundingBox.width, fontHeight};
+        Rectangle itemBox = {listBox.x, y, listBox.width, fontHeight};
+        auto is_in_bounds = [&](const Point& pt) {
+            return internal::is_boxed_in(pt, itemBox)
+                   && internal::is_boxed_in(pt, listBox);
+        };
 
         Color color = mBaseColor;
-
-        bool hoveringOnItem = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), itemBox);
-        bool clickedInBox = internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), boundingBox);
-        bool isItemClicked = ctx.mouse.leftButton.is_clicked()
-                             && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox);
-        if (hoveringOnItem) {
+        bool isHoveringOnItem = is_in_bounds(ctx.mouse.get_cursor_pos());
+        if (isHoveringOnItem) {
             color = internal::lighten_color_by(color, 30);
+        }
 
-            if (isItemClicked && clickedInBox) {
-                color = internal::lighten_color_by(color, 30);
-
+        bool clickedOnItem = is_in_bounds(ctx.mouse.leftButton.get_clicked_pos());
+        if (clickedOnItem) {
+            if (ctx.mouse.leftButton.is_clicked()) {
                 mAction(it - mBegin, *it);
+            }
+
+            if (ctx.mouse.leftButton.is_pressed()) {
+                color = internal::lighten_color_by(color, 30);
             }
         }
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -3,9 +3,14 @@
 
 #include "context.h"
 #include "internal.h"
+#include "reference_widget.h"
+#include <iostream>
 
 namespace reig::reference_widget {
     namespace detail {
+        // FIXME: This cache can't be dropped
+        float& get_scroll_value(const char* title);
+
         template <typename Iter, typename Adapter, typename Action>
         struct list {
             const char* mTitle = "";
@@ -34,7 +39,9 @@ namespace reig::reference_widget {
 template <typename Iter, typename Adapter, typename Action>
 void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Context& ctx) const {
     using namespace reig::primitive;
+    int scrollbarWidth = 30;
     Rectangle listBox = {mBoundingBox};
+    listBox.x += scrollbarWidth;
     ctx.fit_rect_in_window(listBox);
 
     float fontHeight = ctx.get_font_size();
@@ -67,6 +74,14 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
         internal::render_widget_frame(ctx, itemBox, color);
         ctx.render_text(mAdapter(*it), itemBox);
+    }
+
+    auto scrollbarRect = mBoundingBox;
+    scrollbarRect.width = scrollbarWidth;
+    auto itemsCount = mEnd - mBegin;
+    auto& scrolled = detail::get_scroll_value(mTitle);
+    if(ctx.enqueue(scrollbar{scrollbarRect, mBaseColor, scrolled, itemsCount * fontHeight})) {
+        std::cout << "scrolled list: " << scrolled << '\n';
     }
 }
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -48,11 +48,11 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
         bool clickedInBox = internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), boundingBox);
         bool isItemClicked = ctx.mouse.leftButton.is_clicked()
                              && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox);
-        if (hoveringOnItem && clickedInBox) {
-            color = internal::lighten_color_by(color, 20);
+        if (hoveringOnItem) {
+            color = internal::lighten_color_by(color, 30);
 
-            if (isItemClicked) {
-                color = internal::lighten_color_by(color, 20);
+            if (isItemClicked && clickedInBox) {
+                color = internal::lighten_color_by(color, 30);
 
                 mAction(it - mBegin, *it);
             }

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -37,12 +37,13 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
     Rectangle boundingBox = {mBoundingBox};
     ctx.fit_rect_in_window(boundingBox);
 
-    internal::render_widget_frame(ctx, boundingBox, mBaseColor);
-
     float fontHeight = ctx.get_font_size();
     float y = boundingBox.y;
     for (auto it = mBegin; it != mEnd; ++it) {
         Rectangle itemBox = {boundingBox.x, y, boundingBox.width, fontHeight};
+
+        internal::render_widget_frame(ctx, itemBox, mBaseColor);
+
         ctx.render_text(mAdapter(*it), itemBox);
         y += fontHeight;
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -12,8 +12,8 @@ namespace reig::reference_widget {
             primitive::Color mBaseColor;
             Iter mBegin;
             Iter mEnd;
-            Adapter& adapter;
-            Action& action;
+            Adapter& mAdapter;
+            Action& mAction;
 
             void draw(Context& ctx) const;
         };
@@ -40,6 +40,13 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
     ctx.fit_rect_in_window(boundingBox);
 
     ctx.render_rectangle(boundingBox, mBaseColor);
+
+    float fontHeight = ctx.get_font_height();
+    float y = boundingBox.y;
+    for(auto it = mBegin; it != mEnd; ++it) {
+        ctx.render_text(mAdapter(*it), {boundingBox.x, y, boundingBox.width, fontHeight});
+        y += fontHeight;
+    }
 }
 
 #endif //REIG_REFERENCE_WIDGET_LIST_H

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -39,7 +39,7 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
     float fontHeight = ctx.get_font_size();
     float y = listBox.y;
-    for (auto it = mBegin; it != mEnd; ++it, y += fontHeight) {
+    for (auto it = mBegin; it != mEnd && y < listBox.y + listBox.height; ++it, y += fontHeight) {
         Rectangle itemBox = {listBox.x, y, listBox.width, fontHeight};
         auto is_in_bounds = [&](const Point& pt) {
             return internal::is_boxed_in(pt, itemBox)

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -39,19 +39,27 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
     float fontHeight = ctx.get_font_size();
     float y = boundingBox.y;
-    for (auto it = mBegin; it != mEnd; ++it) {
+    for (auto it = mBegin; it != mEnd; ++it, y += fontHeight) {
         Rectangle itemBox = {boundingBox.x, y, boundingBox.width, fontHeight};
 
-        internal::render_widget_frame(ctx, itemBox, mBaseColor);
+        Color color = mBaseColor;
 
-        ctx.render_text(mAdapter(*it), itemBox);
-        y += fontHeight;
+        bool hoveringOnItem = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), itemBox);
+        bool clickedInBox = internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), boundingBox);
+        bool isItemClicked = ctx.mouse.leftButton.is_clicked()
+                             && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox);
+        if (hoveringOnItem && clickedInBox) {
+            color = internal::lighten_color_by(color, 20);
 
-        if (ctx.mouse.leftButton.is_clicked()
-            && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox)
-            && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), boundingBox)) {
-            mAction(it - mBegin, *it);
+            if (isItemClicked) {
+                color = internal::lighten_color_by(color, 20);
+
+                mAction(it - mBegin, *it);
+            }
         }
+
+        internal::render_widget_frame(ctx, itemBox, color);
+        ctx.render_text(mAdapter(*it), itemBox);
     }
 }
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -4,7 +4,6 @@
 #include "context.h"
 #include "internal.h"
 #include "reference_widget.h"
-#include <iostream>
 
 namespace reig::reference_widget {
     namespace detail {
@@ -44,9 +43,13 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
     listBox.x += scrollbarWidth;
     ctx.fit_rect_in_window(listBox);
 
+    auto& scrolled = detail::get_scroll_value(mTitle);
     float fontHeight = ctx.get_font_size();
+    auto itemCount = mEnd - mBegin;
+    auto skippedItemCount = static_cast<int>(scrolled / fontHeight);
+
     float y = listBox.y;
-    for (auto it = mBegin; it != mEnd && y < listBox.y + listBox.height; ++it, y += fontHeight) {
+    for (auto it = mBegin + skippedItemCount; it != mEnd && y < listBox.y + listBox.height; ++it, y += fontHeight) {
         Rectangle itemBox = {listBox.x, y, listBox.width, fontHeight};
         internal::fit_rect_in_other(itemBox, listBox);
 
@@ -78,11 +81,7 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
 
     auto scrollbarRect = mBoundingBox;
     scrollbarRect.width = scrollbarWidth;
-    auto itemsCount = mEnd - mBegin;
-    auto& scrolled = detail::get_scroll_value(mTitle);
-    if(ctx.enqueue(scrollbar{scrollbarRect, mBaseColor, scrolled, itemsCount * fontHeight})) {
-        std::cout << "scrolled list: " << scrolled << '\n';
-    }
+    ctx.enqueue(scrollbar{scrollbarRect, mBaseColor, scrolled, itemCount * fontHeight});
 }
 
 #endif //REIG_REFERENCE_WIDGET_LIST_H

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -40,7 +40,7 @@ void reig::reference_widget::detail::list<Iter, Adapter, Action>::draw(reig::Con
     Rectangle boundingBox = {mBoundingBox};
     ctx.fit_rect_in_window(boundingBox);
 
-    ctx.render_rectangle(boundingBox, mBaseColor);
+    internal::render_widget_frame(ctx, boundingBox, mBaseColor);
 
     float fontHeight = ctx.get_font_size();
     float y = boundingBox.y;


### PR DESCRIPTION
Closes #19 

Changes proposed:
- add a template function to generate a list - also a template widget
- the list widget is able to take any range of items and represent them using an adapter function, and notify clicking on them
- move render_widget_frame to internal
- add fit_rect_in_other to internal to trim rectangles so they fit in another rectangle (crop?)
- the list uses a static cache for scrollbar values

