### PR TITLE
Fix click throughs focus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,14 @@ add_library(reig_lib
         lib/reig/keyboard_shifted.cpp
         lib/reig/exception.h lib/reig/exception.cpp
         lib/reig/internal.h lib/reig/internal.cpp
+        lib/reig/text.h
         lib/reig/context.h lib/reig/context.cpp
         lib/reig/reference_widget.h lib/reig/reference_widget.cpp
         lib/reig/reference_widget_list.h lib/reig/reference_widget_list.cpp
         lib/reig/reference_widget_slider.cpp
         lib/reig/reference_widget_entry.h lib/reig/reference_widget_entry.tcc
-        lib/reig/text.h)
+        lib/reig/focus.h lib/reig/focus.cpp
+        )
 add_library(my::reig_lib ALIAS reig_lib)
 target_compile_features(reig_lib
         PUBLIC

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -315,7 +315,7 @@ private:
             std::cout << "Scrolled: " << scrollValue0 << '\n';
         }
 
-        rect = {rect.x + rect.width + 20, 130, 250, 280};
+        rect = {rect.x + rect.width + 20, 130, 280, 280};
         struct Foo {
             const std::string name;
         };
@@ -333,7 +333,7 @@ private:
                 }
         ).use(mGui.ctx);
 
-        rect = {0, rect.y + rect.height + 20, rect.width + 80, 30};
+        rect = {0, rect.y + rect.height + 20, rect.width + 50, 30};
         widget::scrollbar{rect, colors::black, scrollValue0, 1000.0f}.use(mGui.ctx);
     }
 

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -116,6 +116,8 @@ void reig::Context::start_new_frame() {
 
     keyboard.reset();
 
+    focus.reset_counter();
+
     ++mFrameCounter;
 }
 

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -171,7 +171,9 @@ void reig::Context::end_window() {
     render_text(mCurrentWindow.mTitle, titleBox);
     render_rectangle(bodyBox, colors::mediumGrey | 100_a);
 
-    if (mouse.leftButton.is_pressed() && internal::is_boxed_in(mouse.leftButton.get_clicked_pos(), headerBox)) {
+    if (mouse.leftButton.is_pressed()
+        && internal::is_boxed_in(mouse.leftButton.get_clicked_pos(), headerBox)
+        && focus.claim_for_window(mCurrentWindow.mTitle)) {
         Point moved{
                 mouse.get_cursor_pos().x - mouse.leftButton.get_clicked_pos().x,
                 mouse.get_cursor_pos().y - mouse.leftButton.get_clicked_pos().y
@@ -181,6 +183,8 @@ void reig::Context::end_window() {
         *mCurrentWindow.mY += moved.y;
         mouse.leftButton.mClickedPos.x += moved.x;
         mouse.leftButton.mClickedPos.y += moved.y;
+    } else {
+        focus.release_from_window(mCurrentWindow.mTitle);
     }
 }
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -5,6 +5,7 @@
 #include "mouse.h"
 #include "keyboard.h"
 #include "text.h"
+#include "focus.h"
 #include "stb_truetype.h"
 #include <vector>
 #include <any>
@@ -102,6 +103,7 @@ namespace reig {
         // Inputs
         detail::Mouse mouse;
         detail::Keyboard keyboard;
+        Focus focus;
 
         // Widget renders
         void start_window(char const* title, float& x, float& y);
@@ -141,9 +143,9 @@ namespace reig {
         void render_triangle(primitive::Triangle const& triangle, primitive::Color const& color);
 
     private:
-        std::vector<primitive::Figure> mDrawData;
         detail::Font mFont;
         detail::Window mCurrentWindow;
+        std::vector<primitive::Figure> mDrawData;
 
         RenderHandler mRenderHandler = nullptr;
         std::any mUserPtr;

--- a/lib/reig/focus.cpp
+++ b/lib/reig/focus.cpp
@@ -6,7 +6,7 @@ namespace reig {
     }
 
     bool Focus::claim(int focusId) {
-        if (focusId > mCurrentFocus) {
+        if (focusId > mCurrentFocus && !mFocusedWindow) {
             mCurrentFocus = focusId;
         }
         return mCurrentFocus == focusId;
@@ -29,5 +29,18 @@ namespace reig {
 
     void Focus::reset_counter() {
         mFocusCounter = 0;
+    }
+
+    bool Focus::claim_for_window(const char* window) {
+        if (!mFocusedWindow) {
+            mFocusedWindow = window;
+        }
+        return mFocusedWindow == window;
+    }
+
+    void Focus::release_from_window(const char* window) {
+        if (mFocusedWindow == window) {
+            mFocusedWindow = nullptr;
+        }
     }
 }

--- a/lib/reig/focus.cpp
+++ b/lib/reig/focus.cpp
@@ -5,10 +5,6 @@ namespace reig {
         return ++mFocusCounter;
     }
 
-    bool Focus::is_focused(int focusId) const {
-        return mCurrentFocus == focusId;
-    }
-
     bool Focus::claim(int focusId) {
         if (focusId > mCurrentFocus) {
             mCurrentFocus = focusId;
@@ -19,6 +15,15 @@ namespace reig {
     void Focus::release(int focusId) {
         if (mCurrentFocus == focusId) {
             mCurrentFocus = 0;
+        }
+    }
+
+    bool Focus::handle(int focusId, bool claiming) {
+        if (claiming) {
+            return claim(focusId);
+        } else {
+            release(focusId);
+            return false;
         }
     }
 

--- a/lib/reig/focus.cpp
+++ b/lib/reig/focus.cpp
@@ -1,0 +1,28 @@
+#include "focus.h"
+
+namespace reig {
+    int Focus::create_id() {
+        return ++mFocusCounter;
+    }
+
+    bool Focus::is_focused(int focusId) const {
+        return mCurrentFocus == focusId;
+    }
+
+    bool Focus::claim(int focusId) {
+        if (focusId > mCurrentFocus) {
+            mCurrentFocus = focusId;
+        }
+        return mCurrentFocus == focusId;
+    }
+
+    void Focus::release(int focusId) {
+        if (mCurrentFocus == focusId) {
+            mCurrentFocus = 0;
+        }
+    }
+
+    void Focus::reset_counter() {
+        mFocusCounter = 0;
+    }
+}

--- a/lib/reig/focus.h
+++ b/lib/reig/focus.h
@@ -29,6 +29,11 @@ namespace reig {
 
         void reset_counter();
 
+        bool claim_for_window(const char* window);
+
+        void release_from_window(const char* window);
+
+        const char* mFocusedWindow = nullptr;
         int mCurrentFocus = 0;
         unsigned mFocusCounter = 0;
     };

--- a/lib/reig/focus.h
+++ b/lib/reig/focus.h
@@ -1,0 +1,37 @@
+#ifndef REIG_FOCUS_H
+#define REIG_FOCUS_H
+
+#include "fwd.h"
+
+namespace reig {
+    class Focus {
+    public:
+        Focus() = default;
+
+        Focus(const Focus& other) = delete;
+
+        Focus(Focus&& other) noexcept = delete;
+
+        Focus& operator=(const Focus& other) = delete;
+
+        Focus& operator=(Focus&& other) noexcept = delete;
+
+        int create_id();
+
+        bool is_focused(int focusId) const;
+
+        bool claim(int focusId);
+
+        void release(int focusId);
+
+    private:
+        friend Context;
+
+        void reset_counter();
+
+        int mCurrentFocus = 0;
+        unsigned mFocusCounter = 0;
+    };
+}
+
+#endif //REIG_FOCUS_H

--- a/lib/reig/focus.h
+++ b/lib/reig/focus.h
@@ -18,11 +18,11 @@ namespace reig {
 
         int create_id();
 
-        bool is_focused(int focusId) const;
-
         bool claim(int focusId);
 
         void release(int focusId);
+
+        bool handle(int focusId, bool claiming);
 
     private:
         friend Context;

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -98,14 +98,17 @@ CheckboxModel get_checkbox_model(reig::Context& ctx, const Checkbox& checkbox) {
 
     bool justClicked = ctx.mouse.leftButton.is_clicked()
                        && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), baseArea);
-    bool holdingClick = ctx.mouse.leftButton.is_pressed()
-                        && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), baseArea);
-    if (justClicked && isFocused) {
-        checkbox.mValueRef = !checkbox.mValueRef;
-    }
-    if (holdingClick && isFocused) {
-        baseArea = internal::decrease_rect(baseArea, 4);
-        checkArea = internal::decrease_rect(checkArea, 4);
+    if (isFocused) {
+        if (justClicked) {
+            checkbox.mValueRef = !checkbox.mValueRef;
+        }
+
+        bool holdingClick = ctx.mouse.leftButton.is_pressed()
+                            && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), baseArea);
+        if (holdingClick) {
+            baseArea = internal::decrease_rect(baseArea, 4);
+            checkArea = internal::decrease_rect(checkArea, 4);
+        }
     }
 
     return {baseArea, outlineArea, checkArea, isFocused, hoveringOverArea, justClicked};

--- a/lib/reig/reference_widget_entry.h
+++ b/lib/reig/reference_widget_entry.h
@@ -16,18 +16,6 @@ namespace reig::reference_widget {
 
             void use(Context& ctx) const;
         };
-
-        struct EntryModel {
-            const Rectangle outlineArea;
-            const Rectangle baseArea;
-            const Rectangle caretArea;
-            const bool isSelected = false;
-            const bool isHoveringOverArea = false;
-            const bool isInputModified = false;
-        };
-
-        template <template <class, class> typename Entry, typename String, typename Action>
-        EntryModel get_entry_model(Context& ctx, const Entry<String, Action>& entry);
     }
 
     template <typename Char, typename Action>

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -22,52 +22,6 @@ namespace reig::reference_widget {
 
             void use(Context& ctx) const;
         };
-
-        struct ItemModel {
-            Rectangle itemFrameBox;
-            Rectangle itemBox;
-            bool hoveringOnItem = false;
-            bool holdingClickOnItem = false;
-        };
-
-        template <typename List, typename Iter>
-        ItemModel get_item_model(Context& ctx, const List& list, const Rectangle& listArea,
-                                 float itemY, float fontHeight, const Iter& it, const Iter& begin) {
-            Rectangle itemFrameBox = {listArea.x, itemY, listArea.width, fontHeight};
-            internal::trim_rect_in_other(itemFrameBox, listArea);
-            Rectangle itemBox = internal::decrease_rect(itemFrameBox, 4);
-
-            bool hoveringOnItem = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), itemBox);
-            bool clickedOnItem = internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), itemBox);
-            bool holdingClickOnItem = ctx.mouse.leftButton.is_pressed() && clickedOnItem;
-            if (clickedOnItem) {
-                if (ctx.mouse.leftButton.is_clicked()) {
-                    list.mAction(it - begin, *it);
-                }
-            }
-            if(holdingClickOnItem) {
-                itemBox = internal::decrease_rect(itemBox, 4);
-            }
-
-            return {itemFrameBox, itemBox, hoveringOnItem, holdingClickOnItem};
-        }
-
-        template <typename Adapter, typename Iter>
-        void draw_item_model(Context& ctx, const ItemModel& model, const Color& baseColor, Adapter&& adapter, Iter&& it) {
-            Color primaryColor = baseColor;
-            if (model.hoveringOnItem) {
-                primaryColor = internal::lighten_color_by(primaryColor, 30);
-            }
-            if (model.holdingClickOnItem) {
-                primaryColor = internal::lighten_color_by(primaryColor, 30);
-            }
-
-            Color secondaryColor = internal::get_yiq_contrast(primaryColor);
-            ctx.render_rectangle(model.itemFrameBox, secondaryColor);
-            ctx.render_rectangle(model.itemBox, primaryColor);
-
-            ctx.render_text(adapter(*it), model.itemBox, text::Alignment::LEFT);
-        }
     }
 
     template <typename Range, typename Adapter, typename Action>
@@ -82,25 +36,29 @@ namespace reig::reference_widget {
 
 template <typename Iter, typename Adapter, typename Action>
 void reig::reference_widget::detail::list<Iter, Adapter, Action>::use(reig::Context& ctx) const {
-    int scrollbarWidth = 30;
-    Rectangle listArea = mBoundingBox;
-    listArea.x += scrollbarWidth;
-    ctx.fit_rect_in_window(listArea);
+    {
+        Rectangle listArea = mBoundingBox;
+        ctx.fit_rect_in_window(listArea);
+    }
 
     auto& scrolled = detail::get_scroll_value(mTitle);
     float fontHeight = ctx.get_font_size();
-    auto itemCount = mEnd - mBegin;
     auto skippedItemCount = static_cast<int>(scrolled / fontHeight);
 
-    float y = listArea.y;
-    float maxY = listArea.y + listArea.height;
+    float y = mBoundingBox.y;
+    float maxY = mBoundingBox.y + mBoundingBox.height;
+    float scrollbarWidth = 30.0f;
     for (auto it = mBegin + skippedItemCount; it != mEnd && y < maxY; ++it, y += fontHeight) {
-        auto model = get_item_model(ctx, *this, listArea, y, fontHeight, it, mBegin);
-        draw_item_model(ctx, model, mBaseColor, mAdapter, it);
+        Rectangle itemFrameBox = {mBoundingBox.x + scrollbarWidth, y, mBoundingBox.width, fontHeight};
+        internal::trim_rect_in_other(itemFrameBox, mBoundingBox);
+
+        if (button{mAdapter(*it), itemFrameBox, mBaseColor}.use(ctx)) {
+            mAction(it - mBegin, *it);
+        }
     }
 
-    auto scrollbarArea = mBoundingBox;
-    scrollbarArea.width = scrollbarWidth;
+    auto itemCount = mEnd - mBegin;
+    Rectangle scrollbarArea {mBoundingBox.x, mBoundingBox.y, scrollbarWidth, mBoundingBox.height};
     scrollbar{scrollbarArea, mBaseColor, scrolled, itemCount * fontHeight}.use(ctx);
 }
 

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -79,12 +79,11 @@ SliderModel get_slider_model(reig::Context& ctx, const Slider& slider) {
         size_slider_cursor(cursorArea.y, cursorArea.height, values.valuesNum, values.offset);
     }
 
-    bool hoveringOverArea = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), outlineArea);
-    bool isFocused = ctx.focus.handle(focusId, hoveringOverArea);
-
     bool hoveringOverCursor = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), cursorArea);
+    bool hoveringOverArea = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), outlineArea);
     bool holdingClick = ctx.mouse.leftButton.is_pressed()
                         && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), baseArea);
+    bool isFocused = ctx.focus.handle(focusId, holdingClick || hoveringOverArea);
     bool holdingClickOnSlider = ctx.mouse.leftButton.is_pressed()
                                 && internal::is_boxed_in(ctx.mouse.get_cursor_pos(), baseArea);
     if (isFocused) {
@@ -142,11 +141,10 @@ SliderModel get_scrollbar_model(reig::Context& ctx, const Scrollbar& scrollbar) 
     }
 
     bool hoveringOverArea = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), outlineArea);
-    bool isFocused = ctx.focus.handle(focusId, hoveringOverArea);
-
     bool hoveringOverCursor = internal::is_boxed_in(ctx.mouse.get_cursor_pos(), cursorArea);
     bool holdingClick = ctx.mouse.leftButton.is_pressed()
                         && internal::is_boxed_in(ctx.mouse.leftButton.get_clicked_pos(), baseArea);
+    bool isFocused = ctx.focus.handle(focusId, holdingClick || hoveringOverArea);
     bool holdingClickOnSlider = ctx.mouse.leftButton.is_pressed()
                                 && internal::is_boxed_in(ctx.mouse.get_cursor_pos(), baseArea);
 

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -147,7 +147,6 @@ SliderModel get_scrollbar_model(reig::Context& ctx, const Scrollbar& scrollbar) 
     bool isFocused = ctx.focus.handle(focusId, holdingClick || hoveringOverArea);
     bool holdingClickOnSlider = ctx.mouse.leftButton.is_pressed()
                                 && internal::is_boxed_in(ctx.mouse.get_cursor_pos(), baseArea);
-
     if (isFocused) {
         if (holdingClick) {
             if (orientation == SliderOrientation::HORIZONTAL) {


### PR DESCRIPTION
Closes #56 

Changes proposed:
- Add a focus class to grant widgets their focus id
- Make the widgets ask for focus before doing any job

p.s. It's awful