### PR TITLE
Fix 67

### DIFF
--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -100,7 +100,7 @@ void reig::Context::render_all() {
     if (!mRenderHandler) {
         throw exception::NoRenderHandlerException{};
     }
-    if (mWindows.back().mIsStarted) end_window();
+    end_window();
 
     if (!mDrawData.empty()) {
         using std::move;
@@ -131,11 +131,10 @@ unsigned reig::Context::get_frame_counter() const {
 }
 
 void reig::Context::start_window(char const* aTitle, float& aX, float& aY) {
-    if (!mWindows.empty() && mWindows.back().mIsStarted) end_window();
+    if (!mWindows.empty()) end_window();
 
     detail::Window currentWindow;
 
-    currentWindow.mIsStarted = true;
     currentWindow.mTitle = aTitle;
     currentWindow.mX = &aX;
     currentWindow.mY = &aY;
@@ -183,11 +182,9 @@ void reig::Context::render_windows() {
 }
 
 void reig::Context::end_window() {
-    if (mWindows.empty() || !mWindows.back().mIsStarted) return;
+    if (mWindows.empty()) return;
 
     detail::Window currentWindow = mWindows.back();
-
-    currentWindow.mIsStarted = false;
 
     currentWindow.mWidth += 4;
     currentWindow.mHeight += 4;
@@ -215,22 +212,20 @@ void reig::Context::end_window() {
 }
 
 void reig::detail::Window::fit_rect(Rectangle& rect) {
-    if (mIsStarted) {
-        rect.x += *mX + 4;
-        rect.y += *mY + mTitleBarHeight + 4;
+    rect.x += *mX + 4;
+    rect.y += *mY + mTitleBarHeight + 4;
 
-        if (*mX + mWidth < get_x2(rect)) {
-            mWidth = get_x2(rect) - *mX;
-        }
-        if (*mY + mHeight < get_y2(rect)) {
-            mHeight = get_y2(rect) - *mY;
-        }
-        if (rect.x < *mX) {
-            rect.x = *mX + 4;
-        }
-        if (rect.y < *mY) {
-            rect.y = *mY + 4;
-        }
+    if (*mX + mWidth < get_x2(rect)) {
+        mWidth = get_x2(rect) - *mX;
+    }
+    if (*mY + mHeight < get_y2(rect)) {
+        mHeight = get_y2(rect) - *mY;
+    }
+    if (rect.x < *mX) {
+        rect.x = *mX + 4;
+    }
+    if (rect.y < *mY) {
+        rect.y = *mY + 4;
     }
 }
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -148,6 +148,8 @@ namespace reig {
         void render_triangle(primitive::Triangle const& triangle, primitive::Color const& color);
 
     private:
+        void render_windows();
+
         detail::Font mFont;
         std::vector<detail::Window> mWindows;
         std::vector<primitive::Figure> mDrawData;

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -149,7 +149,7 @@ namespace reig {
 
     private:
         detail::Font mFont;
-        detail::Window mCurrentWindow;
+        std::vector<detail::Window> mWindows;
         std::vector<primitive::Figure> mDrawData;
         Config mConfig;
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -22,14 +22,12 @@ namespace reig {
         };
 
         struct Window {
-            std::vector<primitive::Figure> mDrawData;
             char const* mTitle = nullptr;
             float* mX = nullptr;
             float* mY = nullptr;
             float mWidth = 0.f;
             float mHeight = 0.f;
             float mTitleBarHeight = 0.f;
-            bool mIsStarted = false;
 
             /**
              * Increase the window's width and height to fit rect's bottom right point


### PR DESCRIPTION
Closes #67 

Changes proposed:
- Don't enqueue window drawing inside end_window, but inside render_all
- First windows are drawn, then widgets
- Store all windows to be displayed, not only the current one
- Remove unused isStarted and drawData window's fields


