### PR TITLE
Give windows own draw data buffers

### DIFF
--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -141,7 +141,7 @@ namespace reig {
     }
 
     detail::Window* Context::get_current_window() {
-        if (!mQueuedWindows.empty()) {
+        if (!mQueuedWindows.empty() && !mQueuedWindows.back().isFinished) {
             return &mQueuedWindows.back();
         } else {
             return nullptr;

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -96,6 +96,7 @@ namespace reig {
         end_window();
 
         mRenderHandler(mFreeDrawData, mUserPtr);
+        mFreeDrawData.clear();
         render_windows();
 
         //{{{ persist previous windows
@@ -120,9 +121,6 @@ namespace reig {
     }
 
     void Context::start_frame() {
-        mQueuedWindows.clear();
-        mFreeDrawData.clear();
-
         mouse.leftButton.mIsClicked = false;
         mouse.mScrolled = 0.f;
 

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -100,6 +100,7 @@ namespace reig {
 
         //{{{ persist previous windows
         mPreviousWindows = move(mQueuedWindows);
+        mQueuedWindows.clear();
         std::reverse(begin(mPreviousWindows), end(mPreviousWindows));
         //}}}
     }
@@ -151,6 +152,7 @@ namespace reig {
     void Context::render_windows() {
         for(auto& currentWindow : mQueuedWindows) {
             auto currentWidgetData = move(currentWindow.drawData);
+            currentWindow.drawData.clear();
 
             Rectangle headerBox{
                     *currentWindow.x, *currentWindow.y,
@@ -183,7 +185,10 @@ namespace reig {
             } else {
                 render_rectangle(currentWindow.drawData, bodyBox, mConfig.mWindowBackgroundColor);
             }
+
             mRenderHandler(currentWindow.drawData, mUserPtr);
+            currentWindow.drawData.clear();
+
             mRenderHandler(currentWidgetData, mUserPtr);
         }
     }

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -28,12 +28,17 @@ namespace reig {
         };
 
         struct Window {
-            const char* mTitle = "";
-            float* mX = nullptr;
-            float* mY = nullptr;
-            float mWidth = 0.f;
-            float mHeight = 0.f;
-            float mTitleBarHeight = 0.f;
+            Window(const char* title, float& x, float& y, float width, float height, float titleBarHeight)
+                    : title{title}, x{&x}, y{&y}, width{width}, height{height}, titleBarHeight{titleBarHeight} {}
+
+            DrawData drawData;
+            const char* title = "";
+            float* x = nullptr;
+            float* y = nullptr;
+            float width = 0.f;
+            float height = 0.f;
+            float titleBarHeight = 0.f;
+            bool isFinished = false;
         };
 
         /**
@@ -148,6 +153,8 @@ namespace reig {
         void render_windows();
 
     private:
+        void handle_window_input(detail::Window& window);
+
         friend reig::detail::Mouse;
         friend reig::detail::MouseButton;
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -145,18 +145,17 @@ namespace reig {
         void render_triangle(const primitive::Triangle& triangle, const primitive::Color& color);
 
     private:
-        bool handle_window_focus(const char* window, bool claiming);
-
         void render_text_quads(const std::vector<stbtt_aligned_quad>& quads,
                                float horizontalAlignment, float verticalAlignment);
 
         void render_windows();
 
-    private:
+        bool handle_window_focus(const char* window, bool claiming);
+
         void handle_window_input(detail::Window& window);
 
-        friend reig::detail::Mouse;
-        friend reig::detail::MouseButton;
+        friend ::reig::detail::Mouse;
+        friend ::reig::detail::MouseButton;
 
         detail::Window* get_current_window();
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -145,8 +145,21 @@ namespace reig {
         void render_triangle(const primitive::Triangle& triangle, const primitive::Color& color);
 
     private:
-        void render_text_quads(const std::vector<stbtt_aligned_quad>& quads,
-                               float horizontalAlignment, float verticalAlignment);
+        DrawData& get_current_draw_data_buffer();
+
+        float render_text(DrawData& drawData, const char* text, primitive::Rectangle rect,
+                          text::Alignment alignment = text::Alignment::CENTER, float scale = 1.0f);
+
+        static void render_rectangle(DrawData& drawData, const primitive::Rectangle& rect,
+                                     const primitive::Color& color);
+
+        static void render_rectangle(DrawData& drawData, const primitive::Rectangle& rect, int textureId);
+
+        static void render_triangle(DrawData& drawData, const primitive::Triangle& triangle,
+                                    const primitive::Color& color);
+
+        static void render_text_quads(DrawData& drawData, const std::vector<stbtt_aligned_quad>& quads,
+                                      float horizontalAlignment, float verticalAlignment, int fontTextureId);
 
         void render_windows();
 
@@ -162,7 +175,7 @@ namespace reig {
         const char* mDraggedWindow = nullptr;
         std::vector<detail::Window> mPreviousWindows;
         std::vector<detail::Window> mQueuedWindows;
-        std::vector<primitive::Figure> mDrawData;
+        DrawData mFreeDrawData;
 
         detail::Font mFont;
         Config mConfig;

--- a/lib/reig/mouse.cpp
+++ b/lib/reig/mouse.cpp
@@ -40,8 +40,8 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (internal::is_boxed_in(mCursorPos, as_rect(previousWindow))) {
-                if (currentWindow) {
-                    return currentWindow->mTitle == previousWindow.mTitle;
+                if (currentWindow && !currentWindow->isFinished) {
+                    return currentWindow->title == previousWindow.title;
                 } else {
                     return false;
                 }
@@ -86,8 +86,8 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (internal::is_boxed_in(mClickedPos, as_rect(previousWindow))) {
-                if (currentWindow) {
-                    return currentWindow->mTitle == previousWindow.mTitle;
+                if (currentWindow && !currentWindow->isFinished) {
+                    return currentWindow->title == previousWindow.title;
                 } else {
                     return false;
                 }
@@ -106,8 +106,8 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (clicked_in_rect(as_rect(previousWindow))) {
-                if (currentWindow) {
-                    return currentWindow->mTitle == previousWindow.mTitle;
+                if (currentWindow && !currentWindow->isFinished) {
+                    return currentWindow->title == previousWindow.title;
                 } else {
                     return false;
                 }

--- a/lib/reig/mouse.cpp
+++ b/lib/reig/mouse.cpp
@@ -40,7 +40,7 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (internal::is_boxed_in(mCursorPos, as_rect(previousWindow))) {
-                if (currentWindow && !currentWindow->isFinished) {
+                if (currentWindow) {
                     return currentWindow->title == previousWindow.title;
                 } else {
                     return false;
@@ -86,7 +86,7 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (internal::is_boxed_in(mClickedPos, as_rect(previousWindow))) {
-                if (currentWindow && !currentWindow->isFinished) {
+                if (currentWindow) {
                     return currentWindow->title == previousWindow.title;
                 } else {
                     return false;
@@ -106,7 +106,7 @@ namespace reig::detail {
         bool isRectVisible = true;
         for (auto& previousWindow : mPreviousWindows) {
             if (clicked_in_rect(as_rect(previousWindow))) {
-                if (currentWindow && !currentWindow->isFinished) {
+                if (currentWindow) {
                     return currentWindow->title == previousWindow.title;
                 } else {
                     return false;


### PR DESCRIPTION
Closes #75 

Changes proposed:
- Every window is given it's own DrawData buffer
- All public render_* methods use the current DrawData buffer - the one belonging to the latest non finished window
- Private render_* methods that allow to specify the DrawData buffer
- If there are no non finished windows, the mFreeDrawData buffer is used - this one is rendered below all else.

![image](https://user-images.githubusercontent.com/4677693/39088454-f64a1c0e-45ba-11e8-9e50-2dc7d776a2c0.png)


