### PR TITLE
Store window coordinates in previous windows buffer

### DIFF
--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -222,13 +222,21 @@ private:
     }
 
     struct Window {
+        Window(const char* id, std::string title, float x, float y) : id{id}, title{move(title)}, x{x}, y{y} {}
+        Window(std::string title, float x, float y) : title{move(title)}, x{x}, y{y} {}
+
         std::string title;
+        const char* id = nullptr;
         float x = 0;
         float y = 0;
     };
 
     void start_window(Window& window) {
-        mGui.ctx.start_window(window.title.c_str(), window.x, window.y);
+        if (window.id) {
+            mGui.ctx.start_window(window.id, window.title.c_str(), window.x, window.y);
+        } else {
+            mGui.ctx.start_window(window.title.c_str(), window.x, window.y);
+        }
     }
 
     float mFontScale = 1.0f;
@@ -251,7 +259,7 @@ private:
     Window mButtonsWindow {"Buttons", 30, 30};
     Window mCheckboxesWindow {"Checkboxes", 200, 30};
     Window mSlidersWindow {"Sliders", 430, 30};
-    Window mTextEntryWindow {"Text entry", 30, 250};
+    Window mTextEntryWindow {"entry_window", "Text entries", 30, 250};
     Window mListWindow {"List", 800, 30};
 
     void draw_buttons() {

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -347,7 +347,7 @@ private:
 
         using reig::reference_widget::EntryOuput;
 
-        static std::string entry1;;
+        static std::string entry1;
         if (widget::entry(mGui.ctx, "Entry 1", rect, colors::violet, entry1) == EntryOuput::MODIFIED) {
             std::cout << "Entry 1: " << entry1 << '\n';
         }

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -127,7 +127,7 @@ namespace reig {
         if (!mouse.leftButton.is_clicked()) return;
 
         for (auto it = mPreviousWindows.begin(); it != mPreviousWindows.end(); ++it) {
-            if (mouse.leftButton.just_clicked_in_rect_ignore_windows(detail::as_rect(*it))) {
+            if (mouse.leftButton.just_clicked_in_rect_ignore_windows(detail::get_full_window_rect(*it))) {
                 std::iter_swap(it, mPreviousWindows.begin());
                 break;
             }
@@ -211,44 +211,35 @@ namespace reig {
             auto currentWidgetData = move(currentWindow.drawData);
             currentWindow.drawData.clear();
 
-            Rectangle headerBox{
-                    currentWindow.x, currentWindow.y,
-                    currentWindow.width, currentWindow.titleBarHeight
-            };
+            auto headerRect = detail::get_window_header_rect(currentWindow);
             Triangle headerTriangle{
                     {currentWindow.x + 3.f, currentWindow.y + 3.f},
                     {currentWindow.x + 3.f + currentWindow.titleBarHeight, currentWindow.y + 3.f},
                     {currentWindow.x + 3.f + currentWindow.titleBarHeight / 2.f,
                      currentWindow.y + currentWindow.titleBarHeight - 3.f}
             };
-            Rectangle titleBox{
-                    currentWindow.x + currentWindow.titleBarHeight + 4, currentWindow.y + 4,
-                    currentWindow.width - currentWindow.titleBarHeight - 4, currentWindow.titleBarHeight - 4
-            };
-            Rectangle bodyBox{
-                    currentWindow.x, currentWindow.y + currentWindow.titleBarHeight,
-                    currentWindow.width, currentWindow.height - currentWindow.titleBarHeight
-            };
+            auto titleRect = decrease_rect(headerRect, 4);
+            auto bodyRect = detail::get_window_body_rect(currentWindow);
 
             auto frameColor = it != orderedWindows.end() - 1
                               ? colors::dim_color_by(mConfig.mTitleBackgroundColor, 127)
                               : mConfig.mTitleBackgroundColor;
 
             if (mConfig.mWindowsTextured) {
-                render_rectangle(currentWindow.drawData, headerBox, mConfig.mTitleBackgroundTexture);
+                render_rectangle(currentWindow.drawData, headerRect, mConfig.mTitleBackgroundTexture);
             } else {
-                render_rectangle(currentWindow.drawData, headerBox, frameColor);
+                render_rectangle(currentWindow.drawData, headerRect, frameColor);
             }
             render_triangle(currentWindow.drawData, headerTriangle, colors::lightGrey);
-            render_text(currentWindow.drawData, currentWindow.title, titleBox);
+            render_text(currentWindow.drawData, currentWindow.title, titleRect);
             if (mConfig.mWindowsTextured) {
-                render_rectangle(currentWindow.drawData, bodyBox, mConfig.mWindowBackgroundTexture);
+                render_rectangle(currentWindow.drawData, bodyRect, mConfig.mWindowBackgroundTexture);
             } else {
                 int thickness = 1;
-                render_rectangle(currentWindow.drawData, decrease_rect(bodyBox, thickness),
+                render_rectangle(currentWindow.drawData, decrease_rect(bodyRect, thickness),
                                  mConfig.mWindowBackgroundColor);
 
-                auto frame = get_rect_frame(bodyBox, thickness);
+                auto frame = get_rect_frame(bodyRect, thickness);
                 for (const auto& frameRect : frame) {
                     render_rectangle(currentWindow.drawData, frameRect, frameColor);
                 }

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -145,17 +145,17 @@ namespace reig {
         mPreviousWindows.erase(removeFrom, mPreviousWindows.end());
     }
 
-    bool Context::handle_window_focus(const char* window, bool claiming) {
+    bool Context::handle_window_focus(const Window& window, bool claiming) {
         if (claiming) {
             if (!mDraggedWindow) {
-                mDraggedWindow = window;
+                mDraggedWindow = window.id;
             }
-            return mDraggedWindow == window;
+            return mDraggedWindow == window.id;
         } else {
-            if (mDraggedWindow == window) {
+            if (mDraggedWindow == window.id) {
                 mDraggedWindow = nullptr;
             }
-            return mDraggedWindow != window;
+            return mDraggedWindow != window.id;
         }
     }
 
@@ -180,17 +180,21 @@ namespace reig {
         }
     }
 
-    void Context::start_window(const char* aTitle, float aX, float aY) {
+    void Context::start_window(const char* title, float defaultX, float defaultY) {
+        start_window(title, title, defaultX, defaultY);
+    }
+
+    void Context::start_window(const char* id, const char* title, float defaultX, float defaultY) {
         if (!mQueuedWindows.empty()) end_window();
 
         auto previousWindow = std::find_if(mPreviousWindows.begin(), mPreviousWindows.end(),
-                                           [aTitle](const Window& window) {
-                                               return window.title == aTitle; // TODO: id or title???
+                                           [id](const Window& window) {
+                                               return window.id == id;
                                            });
         if (previousWindow != mPreviousWindows.end()) {
-            mQueuedWindows.emplace_back(aTitle, previousWindow->x, previousWindow->y, 0, 0, mFont.mHeight + 8);
+            mQueuedWindows.emplace_back(id, title, previousWindow->x, previousWindow->y, 0, 0, mFont.mHeight + 8);
         } else {
-            mQueuedWindows.emplace_back(aTitle, aX, aY, 0, 0, mFont.mHeight + 8);
+            mQueuedWindows.emplace_back(id, title, defaultX, defaultY, 0, 0, mFont.mHeight + 8);
         }
     }
 
@@ -272,7 +276,7 @@ namespace reig {
 
         if (mouse.leftButton.is_held()
             && if_visible_window(window, is_point_in_rect(mouse.leftButton.get_clicked_pos(), headerBox))
-            && handle_window_focus(window.id, true)) {
+            && handle_window_focus(window, true)) {
             Point moved{
                     mouse.get_cursor_pos().x - mouse.leftButton.get_clicked_pos().x,
                     mouse.get_cursor_pos().y - mouse.leftButton.get_clicked_pos().y
@@ -283,7 +287,7 @@ namespace reig {
             mouse.leftButton.mClickedPos.x += moved.x;
             mouse.leftButton.mClickedPos.y += moved.y;
         } else {
-            handle_window_focus(window.id, false);
+            handle_window_focus(window, false);
         }
     }
 

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -111,7 +111,7 @@ namespace reig {
             auto& queuedWindow = *it;
             auto previousWindow = std::find_if(mPreviousWindows.begin(), mPreviousWindows.end(),
                                                [&queuedWindow](const Window& window) {
-                                                   return queuedWindow.title == window.title;
+                                                   return queuedWindow.id == window.id;
                                                });
 
             if (previousWindow != mPreviousWindows.end()) {
@@ -139,7 +139,7 @@ namespace reig {
                                          [this](const Window& previousWindow) {
                                              return std::none_of(mQueuedWindows.begin(), mQueuedWindows.end(),
                                                                      [&previousWindow](const Window& window) {
-                                                                         return window.title == previousWindow.title;
+                                                                         return window.id == previousWindow.id;
                                                                      });
                                          });
         mPreviousWindows.erase(removeFrom, mPreviousWindows.end());
@@ -180,12 +180,12 @@ namespace reig {
         }
     }
 
-    void Context::start_window(const char* aTitle, float& aX, float& aY) {
+    void Context::start_window(const char* aTitle, float aX, float aY) {
         if (!mQueuedWindows.empty()) end_window();
 
         auto previousWindow = std::find_if(mPreviousWindows.begin(), mPreviousWindows.end(),
                                            [aTitle](const Window& window) {
-                                               return window.title == aTitle;
+                                               return window.title == aTitle; // TODO: id or title???
                                            });
         if (previousWindow != mPreviousWindows.end()) {
             mQueuedWindows.emplace_back(aTitle, previousWindow->x, previousWindow->y, 0, 0, mFont.mHeight + 8);
@@ -200,7 +200,7 @@ namespace reig {
             auto& previousWindow = *pit;
             auto qit = std::find_if(mQueuedWindows.begin(), mQueuedWindows.end(),
                                    [&previousWindow](const Window& window) {
-                                       return previousWindow.title == window.title;
+                                       return previousWindow.id == window.id;
                                    });
             orderedWindows.push_back(std::ref(*qit));
         }
@@ -272,7 +272,7 @@ namespace reig {
 
         if (mouse.leftButton.is_held()
             && if_visible_window(window, is_point_in_rect(mouse.leftButton.get_clicked_pos(), headerBox))
-            && handle_window_focus(window.title, true)) {
+            && handle_window_focus(window.id, true)) {
             Point moved{
                     mouse.get_cursor_pos().x - mouse.leftButton.get_clicked_pos().x,
                     mouse.get_cursor_pos().y - mouse.leftButton.get_clicked_pos().y
@@ -283,14 +283,14 @@ namespace reig {
             mouse.leftButton.mClickedPos.x += moved.x;
             mouse.leftButton.mClickedPos.y += moved.y;
         } else {
-            handle_window_focus(window.title, false);
+            handle_window_focus(window.id, false);
         }
     }
 
     bool Context::if_visible_window(detail::Window& window, bool condition) {
         for (auto& previousWindow : mPreviousWindows) {
             if (condition) {
-                return window.title == previousWindow.title;
+                return window.id == previousWindow.id;
             }
         }
         return false;

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -85,8 +85,19 @@ namespace reig {
         detail::Keyboard keyboard;
 
         // Widget renders
-        void start_window(const char* title, float x, float y);
-//        void start_window(const char*id, const char* title, float x, float y);
+        /**
+         * Starts a new window, with the given title and starting coordinates.
+         * The windows is given an id, that is equals to the title
+         */
+        void start_window(const char* title, float defaultX, float defaultY);
+
+        /**
+         * Same as start_window without the id parameter.
+         *
+         * Starts a new window, with the given id, title and starting coordinates.
+         * Use this one with a constant id, if you know the window title can change
+         */
+        void start_window(const char* id, const char* title, float defaultX, float defaultY);
 
         void end_window();
 
@@ -145,7 +156,7 @@ namespace reig {
 
         void cleanup_previous_windows();
 
-        bool handle_window_focus(const char* window, bool claiming);
+        bool handle_window_focus(const detail::Window& window, bool claiming);
 
         void handle_window_input(detail::Window& window);
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -85,7 +85,8 @@ namespace reig {
         detail::Keyboard keyboard;
 
         // Widget renders
-        void start_window(const char* title, float& x, float& y);
+        void start_window(const char* title, float x, float y);
+//        void start_window(const char*id, const char* title, float x, float y);
 
         void end_window();
 
@@ -178,7 +179,7 @@ bool reig::Context::if_on_top(C&& condition) {
     for (auto& previousWindow : mPreviousWindows) {
         if (condition(currentWindow, previousWindow)) {
             if (currentWindow) {
-                return currentWindow->title == previousWindow.title;
+                return currentWindow->id == previousWindow.id;
             } else {
                 return false;
             }

--- a/lib/reig/mouse.cpp
+++ b/lib/reig/mouse.cpp
@@ -36,7 +36,7 @@ namespace reig::detail {
         if (mContext.mDraggedWindow || !hoveringOverRect) return false;
 
         bool isRectVisible = mContext.if_on_top([this](Window* currentWindow, Window& previousWindow) {
-            return is_point_in_rect(mCursorPos, as_rect(previousWindow));
+            return is_point_in_rect(mCursorPos, get_full_window_rect(previousWindow));
         });
 
         return hoveringOverRect && isRectVisible;
@@ -73,7 +73,7 @@ namespace reig::detail {
         if (mMouse.mContext.mDraggedWindow || !clickedInRect) return false;
 
         bool isRectVisible = mMouse.mContext.if_on_top([this](Window* currentWindow, Window& previousWindow) {
-            return is_point_in_rect(mClickedPos, as_rect(previousWindow));
+            return is_point_in_rect(mClickedPos, get_full_window_rect(previousWindow));
         });
 
         return clickedInRect && isRectVisible;
@@ -84,7 +84,7 @@ namespace reig::detail {
         if (mMouse.mContext.mDraggedWindow || !justClickedInRect) return false;
 
         bool isRectVisible = mMouse.mContext.if_on_top([this](Window* currentWindow, Window& previousWindow) {
-            return clicked_in_rect(as_rect(previousWindow));
+            return clicked_in_rect(get_full_window_rect(previousWindow));
         });
 
         return justClickedInRect && isRectVisible;

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -19,7 +19,15 @@ namespace reig::detail {
         }
     }
 
-    primitive::Rectangle as_rect(const Window& window) {
+    primitive::Rectangle get_full_window_rect(const Window& window) {
         return {window.x, window.y, window.width, window.height};
+    }
+
+    primitive::Rectangle get_window_header_rect(const Window& window) {
+        return {window.x, window.y, window.width, window.titleBarHeight};
+    }
+
+    primitive::Rectangle get_window_body_rect(const Window& window) {
+        return {window.x, window.y + window.titleBarHeight, window.width, window.height - window.titleBarHeight};
     }
 }

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -2,24 +2,24 @@
 
 namespace reig::detail {
     void fit_rect_in_window(reig::primitive::Rectangle& rect, Window& window) {
-        rect.x += *window.x + 4;
-        rect.y += *window.y + window.titleBarHeight + 4;
+        rect.x += window.x + 4;
+        rect.y += window.y + window.titleBarHeight + 4;
 
-        if (*window.x + window.width < get_x2(rect)) {
-            window.width = get_x2(rect) - *window.x;
+        if (window.x + window.width < get_x2(rect)) {
+            window.width = get_x2(rect) - window.x;
         }
-        if (*window.y + window.height < get_y2(rect)) {
-            window.height = get_y2(rect) - *window.y;
+        if (window.y + window.height < get_y2(rect)) {
+            window.height = get_y2(rect) - window.y;
         }
-        if (rect.x < *window.x) {
-            rect.x = *window.x + 4;
+        if (rect.x < window.x) {
+            rect.x = window.x + 4;
         }
-        if (rect.y < *window.y) {
-            rect.y = *window.y + 4;
+        if (rect.y < window.y) {
+            rect.y = window.y + 4;
         }
     }
 
     primitive::Rectangle as_rect(const Window& window) {
-        return {*window.x, *window.y, window.width, window.height};
+        return {window.x, window.y, window.width, window.height};
     }
 }

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -26,7 +26,11 @@ namespace reig::detail {
      */
     void fit_rect_in_window(primitive::Rectangle& rect, Window& window);
 
-    primitive::Rectangle as_rect(const Window& window);
+    primitive::Rectangle get_full_window_rect(const Window& window);
+
+    primitive::Rectangle get_window_header_rect(const Window& window);
+
+    primitive::Rectangle get_window_body_rect(const Window& window);
 }
 
 #endif //REIG_WINDOW_H

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -6,10 +6,14 @@
 namespace reig::detail {
     struct Window {
         Window(const char* title, float x, float y, float width, float height, float titleBarHeight)
-                : title{title}, x{x}, y{y}, width{width}, height{height}, titleBarHeight{titleBarHeight} {}
+                : Window{title, title, x, y, width, height, titleBarHeight} {}
+
+        Window(const char* id, const char* title, float x, float y, float width, float height, float titleBarHeight)
+                : title{title}, id{id}, x{x}, y{y}, width{width}, height{height}, titleBarHeight{titleBarHeight} {}
 
         DrawData drawData;
         const char* title = "";
+        const char* id = nullptr;
         float x = 0.0f;
         float y = 0.0f;
         float width = 0.f;

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -5,13 +5,13 @@
 
 namespace reig::detail {
     struct Window {
-        Window(const char* title, float& x, float& y, float width, float height, float titleBarHeight)
-                : title{title}, x{&x}, y{&y}, width{width}, height{height}, titleBarHeight{titleBarHeight} {}
+        Window(const char* title, float x, float y, float width, float height, float titleBarHeight)
+                : title{title}, x{x}, y{y}, width{width}, height{height}, titleBarHeight{titleBarHeight} {}
 
         DrawData drawData;
         const char* title = "";
-        float* x = nullptr;
-        float* y = nullptr;
+        float x = 0.0f;
+        float y = 0.0f;
         float width = 0.f;
         float height = 0.f;
         float titleBarHeight = 0.f;


### PR DESCRIPTION
Closes #36 

Changes proposed:
- the start_window method no longer takes references to it's coordinates, but just the starting position
- mPreviousWindows buffer is used to store the actual window coordinates, checking the new window's field "id", which is equal to title by default
- an additional start_window method that also takes an id, in case a title can change, to assign a different id for the window
- additional methods to get window's rectangles - for header and body only

