### PR TITLE
Clean up widget models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(reig_lib
         lib/reig/text.h
         lib/reig/context.h lib/reig/context.cpp
         lib/reig/reference_widget.h lib/reig/reference_widget.cpp
-        lib/reig/reference_widget_list.h lib/reig/reference_widget_list.cpp
+        lib/reig/reference_widget_list.h lib/reig/reference_widget_list.tcc lib/reig/reference_widget_list.cpp
         lib/reig/reference_widget_slider.cpp
         lib/reig/reference_widget_entry.h lib/reig/reference_widget_entry.tcc
         lib/reig/config.h lib/reig/config.cpp

--- a/GL3-TestBed/main.cpp
+++ b/GL3-TestBed/main.cpp
@@ -153,7 +153,7 @@ public:
             float yline = 0; float step = 28;
             ctx.start_window("Cube manipulation", winX, winY);
             
-            if(widget::checkbox(ctx, {0, yline, 25, 25}, colors::kDarkGrey, windowShown)) {
+            if(widget::checkbox(ctx, {0, yline, 25, 25}, colors::kDarkGrey, &windowShown)) {
                 if (widget::button(ctx, "S", {31, yline, 60, 25}, colors::kMediumGrey)) {
                     scaling = 1.f;
                 }

--- a/GL3-TestBed/main.cpp
+++ b/GL3-TestBed/main.cpp
@@ -167,20 +167,20 @@ public:
                 yline += step;
                 widget::label(ctx, "Scale:", {0, yline, 230, 25});
                 yline += step;
-                widget::slider(ctx, {0, yline, 230, 25}, colors::kLightGrey, scaling, 0.1f, 2.5f, 0.1f);
+                widget::slider(ctx, {0, yline, 230, 25}, colors::kLightGrey, &scaling, 0.1f, 2.5f, 0.1f);
                 
                 yline += step;
                 widget::label(ctx, "Rotation:", {0, yline, 230, 25});
                 yline += step;
                 for(int i = 0; i < 3; ++i) {
-                    widget::slider(ctx, {0, yline, 230, 25}, colors::kDarkGrey, rotation[i], 0.f, 360.f, 5.f);
+                    widget::slider(ctx, {0, yline, 230, 25}, colors::kDarkGrey, &rotation[i], 0.f, 360.f, 5.f);
                     yline += step;
                 }
 
                 widget::label(ctx, "Color:", {0, yline, 230, 25});
-                widget::slider(ctx, {0, yline += step, 230, 25}, colors::kRed, cubeColor[0], 0.f, 255.f, 10.f);
-                widget::slider(ctx, {0, yline += step, 230, 25}, colors::kGreen, cubeColor[1], 0.f, 255.f, 10.f);
-                widget::slider(ctx, {0, yline + step, 230, 25}, colors::kBlue, cubeColor[2], 0.f, 255.f, 10.f);
+                widget::slider(ctx, {0, yline += step, 230, 25}, colors::kRed, &cubeColor[0], 0.f, 255.f, 10.f);
+                widget::slider(ctx, {0, yline += step, 230, 25}, colors::kGreen, &cubeColor[1], 0.f, 255.f, 10.f);
+                widget::slider(ctx, {0, yline + step, 230, 25}, colors::kBlue, &cubeColor[2], 0.f, 255.f, 10.f);
             }
             
             shader.use();

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -348,12 +348,12 @@ private:
         using reig::reference_widget::EntryOuput;
 
         static std::string entry1;
-        if (widget::entry(mGui.ctx, "Entry 1", rect, colors::kViolet, entry1) == EntryOuput::kModified) {
+        if (widget::entry(mGui.ctx, "Entry 1", rect, colors::kViolet, &entry1) == EntryOuput::kModified) {
             std::cout << "Entry 1: " << entry1 << '\n';
         }
 
         rect.y += 50;
-        if (widget::entry(mGui.ctx, "Entry 2", rect, colors::kBlack, mTextEntryWindow.title) == EntryOuput::kModified) {
+        if (widget::entry(mGui.ctx, "Entry 2", rect, colors::kBlack, &mTextEntryWindow.title) == EntryOuput::kModified) {
             std::cout << "Entry 2: " << mTextEntryWindow.title << '\n';
         }
     }
@@ -386,7 +386,7 @@ private:
             using reig::reference_widget::EntryOuput;
 
             rect = {rect.x, rect.y + rect.height + 10, rect.width - 120, 40};
-            switch (widget::entry(mGui.ctx, "Add item", rect, colors::kDarkGrey, itemName)) {
+            switch (widget::entry(mGui.ctx, "Add item", rect, colors::kDarkGrey, &itemName)) {
                 case EntryOuput::kSubmitted: {
                     foos.push_back(Foo{itemName});
                     break;

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -244,7 +244,7 @@ private:
     void draw_gui() {
         widget::label(mGui.ctx, mFpsString.c_str(), {0, 0, 128, 32}, reig::text::Alignment::kCenter);
 
-        widget::slider(mGui.ctx, {350, 680, 300, 20}, colors::kGreen, mFontScale, 0.0f, 2.0f, 0.05f);
+        widget::slider(mGui.ctx, {350, 680, 300, 20}, colors::kGreen, &mFontScale, 0.0f, 2.0f, 0.05f);
         primitive::Rectangle rect{0, 700, 1000, 40};
         widget::label(mGui.ctx, "The quick brown fox jumps over the lazy dog", rect,
                       reig::text::Alignment::kCenter, mFontScale);
@@ -314,30 +314,30 @@ private:
 
         static float sliderValue0 = 20;
 //        if (widget::textured_slider{rect, 0, mGui.font.id, sliderValue0, 20, 40, 5}.use(mGui.ctx)) {
-        if (widget::slider(mGui.ctx, rect, color, sliderValue0, 20, 40, 5)) {
+        if (widget::slider(mGui.ctx, rect, color, &sliderValue0, 20, 40, 5)) {
             std::cout << boost::format("Slider 0: new value %.2f\n") % sliderValue0;
         }
 
         rect = {rect.x, rect.y + 40, rect.width + 50, rect.height};
         color = color + 50_g;
         static float sliderValue1 = 5.4f;
-        if (widget::slider(mGui.ctx, rect, color, sliderValue1, 3, 7, 0.1f)) {
+        if (widget::slider(mGui.ctx, rect, color, &sliderValue1, 3, 7, 0.1f)) {
             std::cout << "Slider 1: new value " << sliderValue1 << std::endl;
         }
 
         rect = {rect.x, rect.y + 40, rect.width + 80, rect.height + 10};
         static float sliderValue2 = 0.3f;
-        if (widget::slider(mGui.ctx, rect, {220_r, 200_g, 150_b}, sliderValue2, 0.1f, 0.5f, 0.05f)) {
+        if (widget::slider(mGui.ctx, rect, {220_r, 200_g, 150_b}, &sliderValue2, 0.1f, 0.5f, 0.05f)) {
             std::cout << "Slider 2: new value " << sliderValue2 << std::endl;
         }
 
         static float scrollValue0 = 0.0f;
 
         rect = {0, 5, 30, 200};
-        widget::scrollbar(mGui.ctx, rect, colors::kBlack, scrollValue0, 1000.0f);
+        widget::scrollbar(mGui.ctx, rect, colors::kBlack, &scrollValue0, 1000.0f);
 
         rect = {rect.x + 50, rect.y + 150, rect.height, rect.width};
-        widget::scrollbar(mGui.ctx, rect, colors::kBlack, scrollValue0, 1000.0f);
+        widget::scrollbar(mGui.ctx, rect, colors::kBlack, &scrollValue0, 1000.0f);
     }
 
     void draw_text_entries() {

--- a/SDL-TestBed/main.cpp
+++ b/SDL-TestBed/main.cpp
@@ -287,14 +287,14 @@ private:
 
         static bool checkBox1 = false;
 //        if(widget::textured_checkbox{rect, 0, mGui.font.id, checkBox1}.use(mGui.ctx)) {
-        if (widget::checkbox(mGui.ctx, rect, color, checkBox1)) {
+        if (widget::checkbox(mGui.ctx, rect, color, &checkBox1)) {
             widget::label(mGui.ctx, "checked", {rect.x + rect.width + 5, rect.y, 80, rect.height});
         }
 
         color = color - 100_r + 100_g + 100_b;
         rect = {rect.x + 80, rect.y + 50, 50, 50};
         static bool checkBox2 = true;
-        if (widget::checkbox(mGui.ctx, rect, color, checkBox2)) {
+        if (widget::checkbox(mGui.ctx, rect, color, &checkBox2)) {
             widget::label(mGui.ctx, "o!", {rect.x + rect.width + 5, rect.y, 50, rect.height}, reig::text::Alignment::kLeft);
         } else {
             widget::label(mGui.ctx, "o-O-o!", {rect.x + rect.width + 5, rect.y, 50, rect.height}, reig::text::Alignment::kLeft);
@@ -303,7 +303,7 @@ private:
         color = colors::kWhite;
         rect = {rect.x + 80, rect.y - 50, 25, 25};
         static bool checkBox3 = false;
-        widget::checkbox(mGui.ctx, rect, color, checkBox3);
+        widget::checkbox(mGui.ctx, rect, color, &checkBox3);
     }
 
     void draw_sliders() {
@@ -373,7 +373,7 @@ private:
         start_window(mListWindow);
 
         widget::label(mGui.ctx, "Show list:", {0, 0, 80, 30}, reig::text::Alignment::kLeft);
-        if (widget::checkbox(mGui.ctx, {85, 0, 30, 30}, colors::kWhite, listShown)) {
+        if (widget::checkbox(mGui.ctx, {85, 0, 30, 30}, colors::kWhite, &listShown)) {
             primitive::Rectangle rect = {0, 35, 280, 280};
             widget::list(mGui.ctx, "Test", rect, colors::kBlue, foos,
                          [](const Foo& foo) {

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -1,5 +1,6 @@
 #include "reference_widget.h"
 #include "context.h"
+#include <cassert>
 
 using namespace reig::primitive;
 
@@ -11,16 +12,16 @@ namespace reig::reference_widget {
         const bool is_holding_click = false;
     };
 
-    ButtonModel get_button_model(Context& ctx, Rectangle outline_area) {
-        ctx.fit_rect_in_window(outline_area);
+    ButtonModel get_button_model(Context& ctx, Rectangle bounding_box) {
+        ctx.fit_rect_in_window(bounding_box);
 
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(outline_area);
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(outline_area);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(bounding_box);
         bool is_holding_click = is_hovering_over_area
-                             && ctx.mouse.left_button.clicked_in_rect(outline_area)
+                             && ctx.mouse.left_button.clicked_in_rect(bounding_box)
                              && ctx.mouse.left_button.is_held();
 
-        return {outline_area, is_hovering_over_area, has_just_clicked, is_holding_click};
+        return {bounding_box, is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
     bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
@@ -65,63 +66,70 @@ namespace reig::reference_widget {
     }
 
     struct CheckboxModel {
-        Rectangle base_area;
-        Rectangle outline_area;
-        Rectangle check_area;
-        bool is_hovering_over_area = false;
-        bool has_value_changed = false;
+        const Rectangle bounding_box;
+        const bool is_hovering_over_area = false;
+        const bool has_just_clicked = false;
+        const bool is_holding_click = false;
     };
 
-    CheckboxModel get_checkbox_model(Context& ctx, Rectangle outlineArea, bool& value_ref) {
-        ctx.fit_rect_in_window(outlineArea);
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(outlineArea);
-
-        Rectangle base_area = decrease_rect(outlineArea, 4);
-        Rectangle check_area = decrease_rect(base_area, 4);
-
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(outlineArea);
+    CheckboxModel get_checkbox_model(Context& ctx, Rectangle bounding_box, bool* value) {
+        ctx.fit_rect_in_window(bounding_box);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(bounding_box);
+        bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(bounding_box)
+                                && ctx.mouse.left_button.is_held();
         if (has_just_clicked) {
-            base_area = decrease_rect(base_area, 4);
-            check_area = decrease_rect(check_area, 4);
-            value_ref = !value_ref;
+            *value = !*value;
         }
 
-        bool holding_click = ctx.mouse.left_button.clicked_in_rect(outlineArea) && ctx.mouse.left_button.is_held();
-        if (holding_click) {
-            base_area = decrease_rect(base_area, 4);
-            check_area = decrease_rect(check_area, 4);
-        }
-
-        return {base_area, outlineArea, check_area, is_hovering_over_area, has_just_clicked};
+        return {bounding_box, is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
-    bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool& value_ref) {
-        auto model = get_checkbox_model(ctx, bounding_box, value_ref);
+    bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
+        assert(value != nullptr && "Can't represent a null bool");
+        auto model = get_checkbox_model(ctx, bounding_box, value);
+
+        Rectangle base_area = decrease_rect(model.bounding_box, 4);
+        Rectangle check_area = decrease_rect(base_area, 4);
+        if (model.has_just_clicked) {
+            base_area = decrease_rect(base_area, 4);
+            check_area = decrease_rect(check_area, 4);
+        }
+        if (model.is_holding_click) {
+            base_area = decrease_rect(base_area, 4);
+            check_area = decrease_rect(check_area, 4);
+        }
 
         Color secondary_color = colors::get_yiq_contrast(base_color);
-        ctx.render_rectangle(model.outline_area, secondary_color);
-        ctx.render_rectangle(model.base_area,
+        ctx.render_rectangle(model.bounding_box, secondary_color);
+        ctx.render_rectangle(base_area,
                              model.is_hovering_over_area
                              ? colors::lighten_color_by(base_color, 30)
                              : base_color);
-
-        if (value_ref) {
-            ctx.render_rectangle(model.check_area, secondary_color);
+        if (*value) {
+            ctx.render_rectangle(check_area, secondary_color);
         }
 
-        return value_ref;
+        return *value;
     }
 
-    bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box, int base_texture, int check_texture,
-                                bool& value_ref) {
-        auto model = get_checkbox_model(ctx, bounding_box, value_ref);
+    bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
+                           int base_texture, int check_texture, bool* value) {
+        auto model = get_checkbox_model(ctx, bounding_box, value);
 
-        ctx.render_rectangle(model.outline_area, base_texture);
-
-        if (value_ref) {
-            ctx.render_rectangle(model.check_area, check_texture);
+        Rectangle check_area = decrease_rect(model.bounding_box, 8);
+        if (model.has_just_clicked) {
+            check_area = decrease_rect(check_area, 4);
+        }
+        if (model.is_holding_click) {
+            check_area = decrease_rect(check_area, 4);
         }
 
-        return value_ref;
+        ctx.render_rectangle(model.bounding_box, base_texture);
+        if (*value) {
+            ctx.render_rectangle(check_area, check_texture);
+        }
+
+        return *value;
     }
 }

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -66,30 +66,29 @@ namespace reig::reference_widget {
     }
 
     struct CheckboxModel {
-        const Rectangle bounding_box;
         const bool is_hovering_over_area = false;
         const bool has_just_clicked = false;
         const bool is_holding_click = false;
     };
 
-    CheckboxModel get_checkbox_model(Context& ctx, Rectangle bounding_box, bool* value) {
-        ctx.fit_rect_in_window(bounding_box);
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(bounding_box);
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(bounding_box);
-        bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(bounding_box)
+    CheckboxModel get_checkbox_model(Context& ctx, Rectangle* bounding_box, bool* value) {
+        ctx.fit_rect_in_window(*bounding_box);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
+        bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(*bounding_box)
                                 && ctx.mouse.left_button.is_held();
         if (has_just_clicked) {
             *value = !*value;
         }
 
-        return {bounding_box, is_hovering_over_area, has_just_clicked, is_holding_click};
+        return {is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
     bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
         assert(value != nullptr && "Can't represent a null bool");
-        auto model = get_checkbox_model(ctx, bounding_box, value);
+        auto model = get_checkbox_model(ctx, &bounding_box, value);
 
-        Rectangle base_area = decrease_rect(model.bounding_box, 4);
+        Rectangle base_area = decrease_rect(bounding_box, 4);
         Rectangle check_area = decrease_rect(base_area, 4);
         if (model.has_just_clicked) {
             base_area = decrease_rect(base_area, 4);
@@ -101,7 +100,7 @@ namespace reig::reference_widget {
         }
 
         Color secondary_color = colors::get_yiq_contrast(base_color);
-        ctx.render_rectangle(model.bounding_box, secondary_color);
+        ctx.render_rectangle(bounding_box, secondary_color);
         ctx.render_rectangle(base_area,
                              model.is_hovering_over_area
                              ? colors::lighten_color_by(base_color, 30)
@@ -115,9 +114,9 @@ namespace reig::reference_widget {
 
     bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
                            int base_texture, int check_texture, bool* value) {
-        auto model = get_checkbox_model(ctx, bounding_box, value);
+        auto model = get_checkbox_model(ctx, &bounding_box, value);
 
-        Rectangle check_area = decrease_rect(model.bounding_box, 8);
+        Rectangle check_area = decrease_rect(bounding_box, 8);
         if (model.has_just_clicked) {
             check_area = decrease_rect(check_area, 4);
         }
@@ -125,7 +124,7 @@ namespace reig::reference_widget {
             check_area = decrease_rect(check_area, 4);
         }
 
-        ctx.render_rectangle(model.bounding_box, base_texture);
+        ctx.render_rectangle(bounding_box, base_texture);
         if (*value) {
             ctx.render_rectangle(check_area, check_texture);
         }

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -5,129 +5,129 @@
 using namespace reig::primitive;
 
 namespace reig::reference_widget {
-    struct ButtonModel {
-        const bool is_hovering_over_area = false;
-        const bool has_just_clicked = false;
-        const bool is_holding_click = false;
-    };
+struct ButtonModel {
+    const bool is_hovering_over_area = false;
+    const bool has_just_clicked = false;
+    const bool is_holding_click = false;
+};
 
-    ButtonModel get_button_model(Context& ctx, Rectangle* bounding_box) {
-        ctx.fit_rect_in_window(*bounding_box);
+ButtonModel get_button_model(Context& ctx, Rectangle* bounding_box) {
+    ctx.fit_rect_in_window(*bounding_box);
 
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
-        bool is_holding_click = is_hovering_over_area
-                             && ctx.mouse.left_button.clicked_in_rect(*bounding_box)
-                             && ctx.mouse.left_button.is_held();
+    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+    bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
+    bool is_holding_click = is_hovering_over_area
+                            && ctx.mouse.left_button.clicked_in_rect(*bounding_box)
+                            && ctx.mouse.left_button.is_held();
 
-        return {is_hovering_over_area, has_just_clicked, is_holding_click};
+    return {is_hovering_over_area, has_just_clicked, is_holding_click};
+}
+
+bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
+    auto model = get_button_model(ctx, &bounding_box);
+
+    Color inner_color{base_color};
+    if (model.is_hovering_over_area) {
+        inner_color = colors::lighten_color_by(inner_color, 30);
+    }
+    Rectangle base_area;
+    if (model.is_holding_click) {
+        inner_color = colors::lighten_color_by(inner_color, 30);
+        base_area = decrease_rect(bounding_box, 6);
+    } else {
+        base_area = decrease_rect(bounding_box, 4);
     }
 
-    bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
-        auto model = get_button_model(ctx, &bounding_box);
+    ctx.render_rectangle(bounding_box, colors::get_yiq_contrast(inner_color));
+    ctx.render_rectangle(base_area, inner_color);
+    ctx.render_text(title, base_area);
 
-        Color inner_color{base_color};
-        if (model.is_hovering_over_area) {
-            inner_color = colors::lighten_color_by(inner_color, 30);
-        }
-        Rectangle base_area;
-        if (model.is_holding_click) {
-            inner_color = colors::lighten_color_by(inner_color, 30);
-            base_area = decrease_rect(bounding_box, 6);
-        } else {
-            base_area = decrease_rect(bounding_box, 4);
-        }
+    return model.has_just_clicked;
+}
 
-        ctx.render_rectangle(bounding_box, colors::get_yiq_contrast(inner_color));
-        ctx.render_rectangle(base_area, inner_color);
-        ctx.render_text(title, base_area);
+bool textured_button(Context& ctx, const char* title, Rectangle bounding_box,
+                     int hover_texture, int base_texture) {
+    auto model = get_button_model(ctx, &bounding_box);
 
-        return model.has_just_clicked;
+    int texture = base_texture;
+    if (model.is_holding_click || model.is_hovering_over_area) {
+        texture = hover_texture;
+    }
+    ctx.render_rectangle(bounding_box, texture);
+    ctx.render_text(title, bounding_box);
+
+    return model.has_just_clicked;
+}
+
+void label(Context& ctx, char const* title, Rectangle bounding_box, text::Alignment alignment, float font_scale) {
+    ctx.fit_rect_in_window(bounding_box);
+    ctx.render_text(title, bounding_box, alignment, font_scale);
+}
+
+struct CheckboxModel {
+    const bool is_hovering_over_area = false;
+    const bool has_just_clicked = false;
+    const bool is_holding_click = false;
+};
+
+CheckboxModel get_checkbox_model(Context& ctx, Rectangle* bounding_box, bool* value) {
+    ctx.fit_rect_in_window(*bounding_box);
+    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+    bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
+    bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(*bounding_box)
+                            && ctx.mouse.left_button.is_held();
+    if (has_just_clicked) {
+        *value = !*value;
     }
 
-    bool textured_button(Context& ctx, const char* title, Rectangle bounding_box,
-                         int hover_texture, int base_texture) {
-        auto model = get_button_model(ctx, &bounding_box);
+    return {is_hovering_over_area, has_just_clicked, is_holding_click};
+}
 
-        int texture = base_texture;
-        if (model.is_holding_click || model.is_hovering_over_area) {
-            texture = hover_texture;
-        }
-        ctx.render_rectangle(bounding_box, texture);
-        ctx.render_text(title, bounding_box);
+bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
+    assert(value != nullptr && "Can't represent a null bool");
+    auto model = get_checkbox_model(ctx, &bounding_box, value);
 
-        return model.has_just_clicked;
+    Rectangle base_area = decrease_rect(bounding_box, 4);
+    Rectangle check_area = decrease_rect(base_area, 4);
+    if (model.has_just_clicked) {
+        base_area = decrease_rect(base_area, 4);
+        check_area = decrease_rect(check_area, 4);
+    }
+    if (model.is_holding_click) {
+        base_area = decrease_rect(base_area, 4);
+        check_area = decrease_rect(check_area, 4);
     }
 
-    void label(Context& ctx, char const* title, Rectangle bounding_box, text::Alignment alignment, float font_scale) {
-        ctx.fit_rect_in_window(bounding_box);
-        ctx.render_text(title, bounding_box, alignment, font_scale);
+    Color secondary_color = colors::get_yiq_contrast(base_color);
+    ctx.render_rectangle(bounding_box, secondary_color);
+    ctx.render_rectangle(base_area,
+                         model.is_hovering_over_area
+                         ? colors::lighten_color_by(base_color, 30)
+                         : base_color);
+    if (*value) {
+        ctx.render_rectangle(check_area, secondary_color);
     }
 
-    struct CheckboxModel {
-        const bool is_hovering_over_area = false;
-        const bool has_just_clicked = false;
-        const bool is_holding_click = false;
-    };
+    return *value;
+}
 
-    CheckboxModel get_checkbox_model(Context& ctx, Rectangle* bounding_box, bool* value) {
-        ctx.fit_rect_in_window(*bounding_box);
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
-        bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(*bounding_box)
-                                && ctx.mouse.left_button.is_held();
-        if (has_just_clicked) {
-            *value = !*value;
-        }
+bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
+                       int base_texture, int check_texture, bool* value) {
+    auto model = get_checkbox_model(ctx, &bounding_box, value);
 
-        return {is_hovering_over_area, has_just_clicked, is_holding_click};
+    Rectangle check_area = decrease_rect(bounding_box, 8);
+    if (model.has_just_clicked) {
+        check_area = decrease_rect(check_area, 4);
+    }
+    if (model.is_holding_click) {
+        check_area = decrease_rect(check_area, 4);
     }
 
-    bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
-        assert(value != nullptr && "Can't represent a null bool");
-        auto model = get_checkbox_model(ctx, &bounding_box, value);
-
-        Rectangle base_area = decrease_rect(bounding_box, 4);
-        Rectangle check_area = decrease_rect(base_area, 4);
-        if (model.has_just_clicked) {
-            base_area = decrease_rect(base_area, 4);
-            check_area = decrease_rect(check_area, 4);
-        }
-        if (model.is_holding_click) {
-            base_area = decrease_rect(base_area, 4);
-            check_area = decrease_rect(check_area, 4);
-        }
-
-        Color secondary_color = colors::get_yiq_contrast(base_color);
-        ctx.render_rectangle(bounding_box, secondary_color);
-        ctx.render_rectangle(base_area,
-                             model.is_hovering_over_area
-                             ? colors::lighten_color_by(base_color, 30)
-                             : base_color);
-        if (*value) {
-            ctx.render_rectangle(check_area, secondary_color);
-        }
-
-        return *value;
+    ctx.render_rectangle(bounding_box, base_texture);
+    if (*value) {
+        ctx.render_rectangle(check_area, check_texture);
     }
 
-    bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
-                           int base_texture, int check_texture, bool* value) {
-        auto model = get_checkbox_model(ctx, &bounding_box, value);
-
-        Rectangle check_area = decrease_rect(bounding_box, 8);
-        if (model.has_just_clicked) {
-            check_area = decrease_rect(check_area, 4);
-        }
-        if (model.is_holding_click) {
-            check_area = decrease_rect(check_area, 4);
-        }
-
-        ctx.render_rectangle(bounding_box, base_texture);
-        if (*value) {
-            ctx.render_rectangle(check_area, check_texture);
-        }
-
-        return *value;
-    }
+    return *value;
+}
 }

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -5,129 +5,129 @@
 using namespace reig::primitive;
 
 namespace reig::reference_widget {
-struct ButtonModel {
-    const bool is_hovering_over_area = false;
-    const bool has_just_clicked = false;
-    const bool is_holding_click = false;
-};
+    struct ButtonModel {
+        const bool is_hovering_over_area = false;
+        const bool has_just_clicked = false;
+        const bool is_holding_click = false;
+    };
 
-ButtonModel get_button_model(Context& ctx, Rectangle* bounding_box) {
-    ctx.fit_rect_in_window(*bounding_box);
+    ButtonModel get_button_model(Context& ctx, Rectangle* bounding_box) {
+        ctx.fit_rect_in_window(*bounding_box);
 
-    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
-    bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
-    bool is_holding_click = is_hovering_over_area
-                            && ctx.mouse.left_button.clicked_in_rect(*bounding_box)
-                            && ctx.mouse.left_button.is_held();
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
+        bool is_holding_click = is_hovering_over_area
+                                && ctx.mouse.left_button.clicked_in_rect(*bounding_box)
+                                && ctx.mouse.left_button.is_held();
 
-    return {is_hovering_over_area, has_just_clicked, is_holding_click};
-}
-
-bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
-    auto model = get_button_model(ctx, &bounding_box);
-
-    Color inner_color{base_color};
-    if (model.is_hovering_over_area) {
-        inner_color = colors::lighten_color_by(inner_color, 30);
-    }
-    Rectangle base_area;
-    if (model.is_holding_click) {
-        inner_color = colors::lighten_color_by(inner_color, 30);
-        base_area = decrease_rect(bounding_box, 6);
-    } else {
-        base_area = decrease_rect(bounding_box, 4);
+        return {is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
-    ctx.render_rectangle(bounding_box, colors::get_yiq_contrast(inner_color));
-    ctx.render_rectangle(base_area, inner_color);
-    ctx.render_text(title, base_area);
+    bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
+        auto model = get_button_model(ctx, &bounding_box);
 
-    return model.has_just_clicked;
-}
+        Color inner_color{base_color};
+        if (model.is_hovering_over_area) {
+            inner_color = colors::lighten_color_by(inner_color, 30);
+        }
+        Rectangle base_area;
+        if (model.is_holding_click) {
+            inner_color = colors::lighten_color_by(inner_color, 30);
+            base_area = decrease_rect(bounding_box, 6);
+        } else {
+            base_area = decrease_rect(bounding_box, 4);
+        }
 
-bool textured_button(Context& ctx, const char* title, Rectangle bounding_box,
-                     int hover_texture, int base_texture) {
-    auto model = get_button_model(ctx, &bounding_box);
+        ctx.render_rectangle(bounding_box, colors::get_yiq_contrast(inner_color));
+        ctx.render_rectangle(base_area, inner_color);
+        ctx.render_text(title, base_area);
 
-    int texture = base_texture;
-    if (model.is_holding_click || model.is_hovering_over_area) {
-        texture = hover_texture;
-    }
-    ctx.render_rectangle(bounding_box, texture);
-    ctx.render_text(title, bounding_box);
-
-    return model.has_just_clicked;
-}
-
-void label(Context& ctx, char const* title, Rectangle bounding_box, text::Alignment alignment, float font_scale) {
-    ctx.fit_rect_in_window(bounding_box);
-    ctx.render_text(title, bounding_box, alignment, font_scale);
-}
-
-struct CheckboxModel {
-    const bool is_hovering_over_area = false;
-    const bool has_just_clicked = false;
-    const bool is_holding_click = false;
-};
-
-CheckboxModel get_checkbox_model(Context& ctx, Rectangle* bounding_box, bool* value) {
-    ctx.fit_rect_in_window(*bounding_box);
-    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
-    bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
-    bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(*bounding_box)
-                            && ctx.mouse.left_button.is_held();
-    if (has_just_clicked) {
-        *value = !*value;
+        return model.has_just_clicked;
     }
 
-    return {is_hovering_over_area, has_just_clicked, is_holding_click};
-}
+    bool textured_button(Context& ctx, const char* title, Rectangle bounding_box,
+                         int hover_texture, int base_texture) {
+        auto model = get_button_model(ctx, &bounding_box);
 
-bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
-    assert(value != nullptr && "Can't represent a null bool");
-    auto model = get_checkbox_model(ctx, &bounding_box, value);
+        int texture = base_texture;
+        if (model.is_holding_click || model.is_hovering_over_area) {
+            texture = hover_texture;
+        }
+        ctx.render_rectangle(bounding_box, texture);
+        ctx.render_text(title, bounding_box);
 
-    Rectangle base_area = decrease_rect(bounding_box, 4);
-    Rectangle check_area = decrease_rect(base_area, 4);
-    if (model.has_just_clicked) {
-        base_area = decrease_rect(base_area, 4);
-        check_area = decrease_rect(check_area, 4);
-    }
-    if (model.is_holding_click) {
-        base_area = decrease_rect(base_area, 4);
-        check_area = decrease_rect(check_area, 4);
+        return model.has_just_clicked;
     }
 
-    Color secondary_color = colors::get_yiq_contrast(base_color);
-    ctx.render_rectangle(bounding_box, secondary_color);
-    ctx.render_rectangle(base_area,
-                         model.is_hovering_over_area
-                         ? colors::lighten_color_by(base_color, 30)
-                         : base_color);
-    if (*value) {
-        ctx.render_rectangle(check_area, secondary_color);
+    void label(Context& ctx, char const* title, Rectangle bounding_box, text::Alignment alignment, float font_scale) {
+        ctx.fit_rect_in_window(bounding_box);
+        ctx.render_text(title, bounding_box, alignment, font_scale);
     }
 
-    return *value;
-}
+    struct CheckboxModel {
+        const bool is_hovering_over_area = false;
+        const bool has_just_clicked = false;
+        const bool is_holding_click = false;
+    };
 
-bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
-                       int base_texture, int check_texture, bool* value) {
-    auto model = get_checkbox_model(ctx, &bounding_box, value);
+    CheckboxModel get_checkbox_model(Context& ctx, Rectangle* bounding_box, bool* value) {
+        ctx.fit_rect_in_window(*bounding_box);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
+        bool is_holding_click = ctx.mouse.left_button.clicked_in_rect(*bounding_box)
+                                && ctx.mouse.left_button.is_held();
+        if (has_just_clicked) {
+            *value = !*value;
+        }
 
-    Rectangle check_area = decrease_rect(bounding_box, 8);
-    if (model.has_just_clicked) {
-        check_area = decrease_rect(check_area, 4);
+        return {is_hovering_over_area, has_just_clicked, is_holding_click};
     }
-    if (model.is_holding_click) {
-        check_area = decrease_rect(check_area, 4);
+
+    bool checkbox(Context& ctx, Rectangle bounding_box, Color base_color, bool* value) {
+        assert(value != nullptr && "Can't represent a null bool");
+        auto model = get_checkbox_model(ctx, &bounding_box, value);
+
+        Rectangle base_area = decrease_rect(bounding_box, 4);
+        Rectangle check_area = decrease_rect(base_area, 4);
+        if (model.has_just_clicked) {
+            base_area = decrease_rect(base_area, 4);
+            check_area = decrease_rect(check_area, 4);
+        }
+        if (model.is_holding_click) {
+            base_area = decrease_rect(base_area, 4);
+            check_area = decrease_rect(check_area, 4);
+        }
+
+        Color secondary_color = colors::get_yiq_contrast(base_color);
+        ctx.render_rectangle(bounding_box, secondary_color);
+        ctx.render_rectangle(base_area,
+                             model.is_hovering_over_area
+                             ? colors::lighten_color_by(base_color, 30)
+                             : base_color);
+        if (*value) {
+            ctx.render_rectangle(check_area, secondary_color);
+        }
+
+        return *value;
     }
 
-    ctx.render_rectangle(bounding_box, base_texture);
-    if (*value) {
-        ctx.render_rectangle(check_area, check_texture);
-    }
+    bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box,
+                           int base_texture, int check_texture, bool* value) {
+        auto model = get_checkbox_model(ctx, &bounding_box, value);
 
-    return *value;
-}
+        Rectangle check_area = decrease_rect(bounding_box, 8);
+        if (model.has_just_clicked) {
+            check_area = decrease_rect(check_area, 4);
+        }
+        if (model.is_holding_click) {
+            check_area = decrease_rect(check_area, 4);
+        }
+
+        ctx.render_rectangle(bounding_box, base_texture);
+        if (*value) {
+            ctx.render_rectangle(check_area, check_texture);
+        }
+
+        return *value;
+    }
 }

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -6,26 +6,25 @@ using namespace reig::primitive;
 
 namespace reig::reference_widget {
     struct ButtonModel {
-        const Rectangle bounding_box;
         const bool is_hovering_over_area = false;
         const bool has_just_clicked = false;
         const bool is_holding_click = false;
     };
 
-    ButtonModel get_button_model(Context& ctx, Rectangle bounding_box) {
-        ctx.fit_rect_in_window(bounding_box);
+    ButtonModel get_button_model(Context& ctx, Rectangle* bounding_box) {
+        ctx.fit_rect_in_window(*bounding_box);
 
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(bounding_box);
-        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(bounding_box);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*bounding_box);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(*bounding_box);
         bool is_holding_click = is_hovering_over_area
-                             && ctx.mouse.left_button.clicked_in_rect(bounding_box)
+                             && ctx.mouse.left_button.clicked_in_rect(*bounding_box)
                              && ctx.mouse.left_button.is_held();
 
-        return {bounding_box, is_hovering_over_area, has_just_clicked, is_holding_click};
+        return {is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
     bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
-        auto model = get_button_model(ctx, bounding_box);
+        auto model = get_button_model(ctx, &bounding_box);
 
         Color inner_color{base_color};
         if (model.is_hovering_over_area) {
@@ -34,12 +33,12 @@ namespace reig::reference_widget {
         Rectangle base_area;
         if (model.is_holding_click) {
             inner_color = colors::lighten_color_by(inner_color, 30);
-            base_area = decrease_rect(model.bounding_box, 6);
+            base_area = decrease_rect(bounding_box, 6);
         } else {
-            base_area = decrease_rect(model.bounding_box, 4);
+            base_area = decrease_rect(bounding_box, 4);
         }
 
-        ctx.render_rectangle(model.bounding_box, colors::get_yiq_contrast(inner_color));
+        ctx.render_rectangle(bounding_box, colors::get_yiq_contrast(inner_color));
         ctx.render_rectangle(base_area, inner_color);
         ctx.render_text(title, base_area);
 
@@ -48,14 +47,14 @@ namespace reig::reference_widget {
 
     bool textured_button(Context& ctx, const char* title, Rectangle bounding_box,
                          int hover_texture, int base_texture) {
-        auto model = get_button_model(ctx, bounding_box);
+        auto model = get_button_model(ctx, &bounding_box);
 
         int texture = base_texture;
         if (model.is_holding_click || model.is_hovering_over_area) {
             texture = hover_texture;
         }
-        ctx.render_rectangle(model.bounding_box, texture);
-        ctx.render_text(title, model.bounding_box);
+        ctx.render_rectangle(bounding_box, texture);
+        ctx.render_text(title, bounding_box);
 
         return model.has_just_clicked;
     }

--- a/lib/reig/reference_widget.cpp
+++ b/lib/reig/reference_widget.cpp
@@ -5,44 +5,42 @@ using namespace reig::primitive;
 
 namespace reig::reference_widget {
     struct ButtonModel {
-        Rectangle outline_area;
-        Rectangle base_area;
-        bool is_hovering_over_area = false;
-        bool has_just_clicked = false;
-        bool is_holding_click = false;
+        const Rectangle bounding_box;
+        const bool is_hovering_over_area = false;
+        const bool has_just_clicked = false;
+        const bool is_holding_click = false;
     };
 
-    ButtonModel get_button_model(Context& ctx, Rectangle outlineArea) {
-        ctx.fit_rect_in_window(outlineArea);
+    ButtonModel get_button_model(Context& ctx, Rectangle outline_area) {
+        ctx.fit_rect_in_window(outline_area);
 
-        ButtonModel model;
-        model.is_hovering_over_area = ctx.mouse.is_hovering_over_rect(outlineArea);
-        model.has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(outlineArea);
-        model.is_holding_click = model.is_hovering_over_area
-                             && ctx.mouse.left_button.clicked_in_rect(outlineArea)
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(outline_area);
+        bool has_just_clicked = ctx.mouse.left_button.just_clicked_in_rect(outline_area);
+        bool is_holding_click = is_hovering_over_area
+                             && ctx.mouse.left_button.clicked_in_rect(outline_area)
                              && ctx.mouse.left_button.is_held();
 
-        model.outline_area = outlineArea;
-        model.base_area = model.is_holding_click
-                         ? decrease_rect(outlineArea, 6)
-                         : decrease_rect(outlineArea, 4);
-
-        return model;
+        return {outline_area, is_hovering_over_area, has_just_clicked, is_holding_click};
     }
 
-    bool button(Context& ctx, const char* aTitle, Rectangle bounding_box, Color base_color) {
+    bool button(Context& ctx, const char* title, Rectangle bounding_box, Color base_color) {
         auto model = get_button_model(ctx, bounding_box);
 
         Color inner_color{base_color};
         if (model.is_hovering_over_area) {
             inner_color = colors::lighten_color_by(inner_color, 30);
         }
+        Rectangle base_area;
         if (model.is_holding_click) {
             inner_color = colors::lighten_color_by(inner_color, 30);
+            base_area = decrease_rect(model.bounding_box, 6);
+        } else {
+            base_area = decrease_rect(model.bounding_box, 4);
         }
-        ctx.render_rectangle(model.outline_area, colors::get_yiq_contrast(inner_color));
-        ctx.render_rectangle(model.base_area, inner_color);
-        ctx.render_text(aTitle, model.base_area);
+
+        ctx.render_rectangle(model.bounding_box, colors::get_yiq_contrast(inner_color));
+        ctx.render_rectangle(base_area, inner_color);
+        ctx.render_text(title, base_area);
 
         return model.has_just_clicked;
     }
@@ -55,8 +53,8 @@ namespace reig::reference_widget {
         if (model.is_holding_click || model.is_hovering_over_area) {
             texture = hover_texture;
         }
-        ctx.render_rectangle(model.outline_area, texture);
-        ctx.render_text(title, model.outline_area);
+        ctx.render_rectangle(model.bounding_box, texture);
+        ctx.render_text(title, model.bounding_box);
 
         return model.has_just_clicked;
     }

--- a/lib/reig/reference_widget.h
+++ b/lib/reig/reference_widget.h
@@ -79,21 +79,21 @@ namespace reig::reference_widget {
      * @brief Renders a checkbox
      * @param bounding_box Checkbox's position and size
      * @param base_color Checkbox's base color
-     * @param value_ref A reference to the bool to be changed
+     * @param value A bool to be represented
      * @return True if value is true
      */
-    bool checkbox(Context& ctx, primitive::Rectangle bounding_box, primitive::Color base_color, bool& value_ref);
+    bool checkbox(Context& ctx, primitive::Rectangle bounding_box, primitive::Color base_color, bool* value);
 
     /**
      * @brief Renders a textured checkbox
      * @param bounding_box Checkbox's position and size
      * @param base_texture Checkbox's base texture
      * @param check_texture Checkbox's filling texture
-     * @param value_ref A reference to the bool to be changed
+     * @param value A reference to the bool to be changed
      * @return True if value is true
      */
     bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box, int base_texture, int check_texture,
-                           bool& value_ref);
+                           bool* value);
 }
 
 #endif //REIG_REFERENCE_WIDGET_H

--- a/lib/reig/reference_widget.h
+++ b/lib/reig/reference_widget.h
@@ -41,17 +41,16 @@ namespace reig::reference_widget {
      * @brief Renders a slider.
      * @param bounding_box Slider's bounding box
      * @param base_color Slider's base color
-     * @param value_ref A reference to the value to be represented and changed
+     * @param value A reference to the value to be represented and changed
      * @param min The lowest represantable value
      * @param max The highest represantable value
      * @param step The discrete portion by which the value can change
      * @return True if value changed
      */
     bool slider(Context& ctx, primitive::Rectangle bounding_box, primitive::Color base_color,
-                float& value_ref, float min, float max, float step);
+                float* value, float min, float max, float step);
 
     /**
-     * @brief
      * @brief Renders a slider.
      * @param bounding_box Slider's bounding box
      * @param base_texture Slider's base texture index
@@ -62,24 +61,25 @@ namespace reig::reference_widget {
      * @param step The discrete portion by which the value can change
      * @return True if value changed
      */
-    bool textured_slider(Context& ctx, primitive::Rectangle bounding_box, int base_texture, int cursor_texture,
-                         float& value_ref, float min, float max, float step);
+    bool textured_slider(Context& ctx, primitive::Rectangle bounding_box,
+                         int base_texture, int cursor_texture,
+                         float* value, float min, float max, float step);
 
     /**
      * @brief Renders a vertical scrollbar
      * @param bounding_box Scrollbar's position and size
      * @param base_color Checkbox's base color
-     * @param value_ref A reference to the float to be changed
+     * @param value A reference to the float to be changed
      * @return True if value changed
      */
     bool scrollbar(Context& ctx, primitive::Rectangle bounding_box, primitive::Color base_color,
-                   float& value_ref, float view_size);
+                   float* value, float view_size);
 
     /**
      * @brief Renders a checkbox
      * @param bounding_box Checkbox's position and size
      * @param base_color Checkbox's base color
-     * @param value A bool to be represented
+     * @param value A reference to the bool to be represented
      * @return True if value is true
      */
     bool checkbox(Context& ctx, primitive::Rectangle bounding_box, primitive::Color base_color, bool* value);
@@ -89,7 +89,7 @@ namespace reig::reference_widget {
      * @param bounding_box Checkbox's position and size
      * @param base_texture Checkbox's base texture
      * @param check_texture Checkbox's filling texture
-     * @param value A reference to the bool to be changed
+     * @param value A reference to the bool to be represented
      * @return True if value is true
      */
     bool textured_checkbox(Context& ctx, primitive::Rectangle bounding_box, int base_texture, int check_texture,

--- a/lib/reig/reference_widget_entry.h
+++ b/lib/reig/reference_widget_entry.h
@@ -14,7 +14,7 @@ namespace reig::reference_widget {
 
     template <typename Char>
     EntryOuput entry(Context& ctx, const char* title, const primitive::Rectangle& bounding_area,
-                     const primitive::Color& base_color, std::basic_string<Char>& value_ref);
+                     const primitive::Color& base_color, std::basic_string<Char>* value);
 }
 
 #include "reference_widget_entry.tcc"

--- a/lib/reig/reference_widget_entry.h
+++ b/lib/reig/reference_widget_entry.h
@@ -13,7 +13,7 @@ namespace reig::reference_widget {
     };
 
     template <typename Char>
-    EntryOuput entry(Context& ctx, const char* title, const primitive::Rectangle& bounding_area,
+    EntryOuput entry(Context& ctx, const char* title, primitive::Rectangle bounding_box,
                      const primitive::Color& base_color, std::basic_string<Char>* value);
 }
 

--- a/lib/reig/reference_widget_entry.tcc
+++ b/lib/reig/reference_widget_entry.tcc
@@ -2,6 +2,7 @@
 #define REIG_REFERENCE_WIDGET_ENTRY_TCC
 
 #include "reference_widget_entry.h"
+#include <cassert>
 
 namespace reig::reference_widget {
     namespace detail {
@@ -20,7 +21,8 @@ namespace reig::reference_widget {
 
     template <typename C>
     EntryOuput entry(reig::Context& ctx, const char* title, const primitive::Rectangle& bounding_area,
-                     const primitive::Color& base_color, std::basic_string<C>& value_ref) {
+                     const primitive::Color& base_color, std::basic_string<C>* value) {
+        assert(value != nullptr && "Can't represent null string");
         using namespace primitive;
         Rectangle outline_area = bounding_area;
         ctx.fit_rect_in_window(outline_area);
@@ -44,15 +46,15 @@ namespace reig::reference_widget {
             Key key_type = ctx.keyboard.get_pressed_key_type();
             switch (key_type) {
                 case Key::kChar: {
-                    value_ref += ctx.keyboard.get_pressed_char();
+                    *value += ctx.keyboard.get_pressed_char();
                     output = EntryOuput::kModified;
                     break;
                 }
 
                 case Key::kBackspace: {
                     using std::empty;
-                    if (!empty(value_ref)) {
-                        value_ref.pop_back();
+                    if (!empty(*value)) {
+                        value->pop_back();
                         output = EntryOuput::kModified;
                     }
                     break;
@@ -78,14 +80,16 @@ namespace reig::reference_widget {
 
         detail::EntryModel model{outline_area, base_area, caret_area, is_selected, is_holding_click};
 
-        display_entry_model(ctx, model, base_color, value_ref, title);
+        display_entry_model(ctx, model, base_color, *value, title);
 
         return output;
     }
 
     template <typename C>
     void detail::display_entry_model(Context& ctx, const EntryModel& model,
-                                     primitive::Color primary_color, const std::basic_string<C>& value_ref, const char* title) {
+                                     primitive::Color primary_color,
+                                     const std::basic_string<C>& value_ref,
+                                     const char* title) {
         using namespace primitive;
         Color secondary_color = colors::get_yiq_contrast(primary_color);
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -46,7 +46,7 @@ namespace reig::reference_widget {
 
         auto itemCount = elem_end - elem_begin;
         Rectangle scrollbar_area {bounding_box.x, bounding_box.y, scrollbar_width, bounding_box.height};
-        scrollbar(ctx, scrollbar_area, base_color, scrolled, itemCount * font_height);
+        scrollbar(ctx, scrollbar_area, base_color, &scrolled, itemCount * font_height);
     };
 }
 

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -11,43 +11,10 @@ namespace reig::reference_widget {
     }
 
     template <typename Range, typename Adapter, typename Action>
-    auto list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
-              const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action) {
-        using namespace primitive;
-        using std::begin;
-        using std::end;
-        auto elem_begin = begin(range);
-        auto elem_end = end(range);
-        {
-            Rectangle list_area = bounding_box;
-            ctx.fit_rect_in_window(list_area);
-
-            using namespace colors::operators;
-            using namespace colors::literals;
-            ctx.render_rectangle(list_area, colors::get_yiq_contrast(base_color - 50_a));
-            ctx.render_rectangle(decrease_rect(list_area, 2), base_color - 50_a);
-        }
-
-        auto& scrolled = detail::get_scroll_value(scrollbar_id);
-        float font_height = ctx.get_font_size();
-        auto skipped_item_count = static_cast<int>(scrolled / font_height);
-
-        float y = bounding_box.y;
-        float max_y = get_y2(bounding_box);
-        float scrollbar_width = 30.0f;
-        for (auto it = elem_begin + skipped_item_count; it != elem_end && y < max_y; ++it, y += font_height) {
-            Rectangle item_frame_box = {bounding_box.x + scrollbar_width, y, bounding_box.width, font_height};
-            trim_rect_in_other(item_frame_box, bounding_box);
-
-            if (button(ctx, adapter(*it), item_frame_box, base_color)) {
-                action(it - elem_begin, *it);
-            }
-        }
-
-        auto itemCount = elem_end - elem_begin;
-        Rectangle scrollbar_area {bounding_box.x, bounding_box.y, scrollbar_width, bounding_box.height};
-        scrollbar(ctx, scrollbar_area, base_color, &scrolled, itemCount * font_height);
-    };
+    void list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
+              const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action);
 }
+
+#include "reference_widget_list.tcc"
 
 #endif //REIG_REFERENCE_WIDGET_LIST_H

--- a/lib/reig/reference_widget_list.h
+++ b/lib/reig/reference_widget_list.h
@@ -11,7 +11,7 @@ namespace reig::reference_widget {
     }
 
     template <typename Range, typename Adapter, typename Action>
-    auto list(Context& ctx, const char* scrollbarId, const primitive::Rectangle& bounding_box,
+    auto list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
               const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action) {
         using namespace primitive;
         using std::begin;
@@ -28,7 +28,7 @@ namespace reig::reference_widget {
             ctx.render_rectangle(decrease_rect(list_area, 2), base_color - 50_a);
         }
 
-        auto& scrolled = detail::get_scroll_value(scrollbarId);
+        auto& scrolled = detail::get_scroll_value(scrollbar_id);
         float font_height = ctx.get_font_size();
         auto skipped_item_count = static_cast<int>(scrolled / font_height);
 

--- a/lib/reig/reference_widget_list.tcc
+++ b/lib/reig/reference_widget_list.tcc
@@ -4,45 +4,44 @@
 #include "reference_widget_list.h"
 
 namespace reig::reference_widget {
-template <typename Range, typename Adapter, typename Action>
-void list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
-          const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action) {
-    using namespace primitive;
-    using std::begin;
-    using std::end;
-    auto elem_begin = begin(range);
-    auto elem_end = end(range);
-    {
-        Rectangle list_area = bounding_box;
-        ctx.fit_rect_in_window(list_area);
+    template <typename Range, typename Adapter, typename Action>
+    void list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
+              const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action) {
+        using namespace primitive;
+        using std::begin;
+        using std::end;
+        auto elem_begin = begin(range);
+        auto elem_end = end(range);
+        {
+            Rectangle list_area = bounding_box;
+            ctx.fit_rect_in_window(list_area);
 
-        using namespace colors::operators;
-        using namespace colors::literals;
-        ctx.render_rectangle(list_area, colors::get_yiq_contrast(base_color - 50_a));
-        ctx.render_rectangle(decrease_rect(list_area, 2), base_color - 50_a);
-    }
-
-    auto& scrolled = detail::get_scroll_value(scrollbar_id);
-    float font_height = ctx.get_font_size();
-    auto skipped_item_count = static_cast<int>(scrolled / font_height);
-
-    float y = bounding_box.y;
-    float max_y = get_y2(bounding_box);
-    float scrollbar_width = 30.0f;
-    for (auto it = elem_begin + skipped_item_count; it != elem_end && y < max_y; ++it, y += font_height) {
-        Rectangle item_frame_box = {bounding_box.x + scrollbar_width, y, bounding_box.width, font_height};
-        trim_rect_in_other(item_frame_box, bounding_box);
-
-        if (button(ctx, adapter(*it), item_frame_box, base_color)) {
-            action(it - elem_begin, *it);
+            using namespace colors::operators;
+            using namespace colors::literals;
+            ctx.render_rectangle(list_area, colors::get_yiq_contrast(base_color - 50_a));
+            ctx.render_rectangle(decrease_rect(list_area, 2), base_color - 50_a);
         }
-    }
 
-    auto itemCount = elem_end - elem_begin;
-    Rectangle scrollbar_area {bounding_box.x, bounding_box.y, scrollbar_width, bounding_box.height};
-    scrollbar(ctx, scrollbar_area, base_color, &scrolled, itemCount * font_height);
-};
+        auto& scrolled = detail::get_scroll_value(scrollbar_id);
+        float font_height = ctx.get_font_size();
+        auto skipped_item_count = static_cast<int>(scrolled / font_height);
+
+        float y = bounding_box.y;
+        float max_y = get_y2(bounding_box);
+        float scrollbar_width = 30.0f;
+        for (auto it = elem_begin + skipped_item_count; it != elem_end && y < max_y; ++it, y += font_height) {
+            Rectangle item_frame_box = {bounding_box.x + scrollbar_width, y, bounding_box.width, font_height};
+            trim_rect_in_other(item_frame_box, bounding_box);
+
+            if (button(ctx, adapter(*it), item_frame_box, base_color)) {
+                action(it - elem_begin, *it);
+            }
+        }
+
+        auto itemCount = elem_end - elem_begin;
+        Rectangle scrollbar_area{bounding_box.x, bounding_box.y, scrollbar_width, bounding_box.height};
+        scrollbar(ctx, scrollbar_area, base_color, &scrolled, itemCount * font_height);
+    };
 }
-
 
 #endif //REIG_REFERENCE_WIDGET_LIST_TCC

--- a/lib/reig/reference_widget_list.tcc
+++ b/lib/reig/reference_widget_list.tcc
@@ -1,0 +1,48 @@
+#ifndef REIG_REFERENCE_WIDGET_LIST_TCC
+#define REIG_REFERENCE_WIDGET_LIST_TCC
+
+#include "reference_widget_list.h"
+
+namespace reig::reference_widget {
+template <typename Range, typename Adapter, typename Action>
+void list(Context& ctx, const char* scrollbar_id, const primitive::Rectangle& bounding_box,
+          const primitive::Color& base_color, Range&& range, Adapter&& adapter, Action&& action) {
+    using namespace primitive;
+    using std::begin;
+    using std::end;
+    auto elem_begin = begin(range);
+    auto elem_end = end(range);
+    {
+        Rectangle list_area = bounding_box;
+        ctx.fit_rect_in_window(list_area);
+
+        using namespace colors::operators;
+        using namespace colors::literals;
+        ctx.render_rectangle(list_area, colors::get_yiq_contrast(base_color - 50_a));
+        ctx.render_rectangle(decrease_rect(list_area, 2), base_color - 50_a);
+    }
+
+    auto& scrolled = detail::get_scroll_value(scrollbar_id);
+    float font_height = ctx.get_font_size();
+    auto skipped_item_count = static_cast<int>(scrolled / font_height);
+
+    float y = bounding_box.y;
+    float max_y = get_y2(bounding_box);
+    float scrollbar_width = 30.0f;
+    for (auto it = elem_begin + skipped_item_count; it != elem_end && y < max_y; ++it, y += font_height) {
+        Rectangle item_frame_box = {bounding_box.x + scrollbar_width, y, bounding_box.width, font_height};
+        trim_rect_in_other(item_frame_box, bounding_box);
+
+        if (button(ctx, adapter(*it), item_frame_box, base_color)) {
+            action(it - elem_begin, *it);
+        }
+    }
+
+    auto itemCount = elem_end - elem_begin;
+    Rectangle scrollbar_area {bounding_box.x, bounding_box.y, scrollbar_width, bounding_box.height};
+    scrollbar(ctx, scrollbar_area, base_color, &scrolled, itemCount * font_height);
+};
+}
+
+
+#endif //REIG_REFERENCE_WIDGET_LIST_TCC

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -37,10 +37,10 @@ float get_distance_to_slider(float mouse_cursor_coord, float cursor_size, float 
 }
 
 void progress_slider_value(float mouse_cursor_coord, float cursor_size,
-                           float slider_cursor_coord, float step, float& value) {
+                           float slider_cursor_coord, float step, float* value) {
     float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
     if (math::abs(distance) > cursor_size / 2) {
-        value += static_cast<int>(distance / cursor_size) * step;
+        *value += static_cast<int>(distance / cursor_size) * step;
     }
 }
 
@@ -104,10 +104,10 @@ SliderModel get_slider_model(Context& ctx, Rectangle* outline_area, float* value
     if (is_holding_click_on_slider) {
         if (orientation == SliderOrientation::kHorizontal) {
             progress_slider_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                  step, values.value);
+                                  step, &values.value);
         } else {
             progress_slider_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                  step, values.value);
+                                  step, &values.value);
         }
     } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
         values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -3,228 +3,228 @@
 #include "context.h"
 #include <cassert>
 
+using namespace reig::primitive;
+
 namespace reig::reference_widget {
-    using namespace primitive;
+struct SliderValues {
+    float min = 0.0f;
+    float max = 0.0f;
+    float value = 0.0f;
+    int offset = 0;
+    int num_values = 0;
+};
 
-    struct SliderValues {
-        float min = 0.0f;
-        float max = 0.0f;
-        float value = 0.0f;
-        int offset = 0;
-        int num_values = 0;
+SliderValues prepare_slider_values(float min, float max, float value, float step) {
+    float min_end = math::min(min, max);
+    float max_end = math::max(min, max);
+    return SliderValues{
+            min_end, max_end, math::clamp(value, min_end, max_end),
+            static_cast<int>((value - min_end) / step),
+            static_cast<int>((max_end - min_end) / step + 1)
     };
+};
 
-    SliderValues prepare_slider_values(float min, float max, float value, float step) {
-        float min_end = math::min(min, max);
-        float max_end = math::max(min, max);
-        return SliderValues{
-                min_end, max_end, math::clamp(value, min_end, max_end),
-                static_cast<int>((value - min_end) / step),
-                static_cast<int>((max_end - min_end) / step + 1)
-        };
-    };
+void size_slider_cursor(float& coord, float& size, int num_values, int offset) {
+    size /= num_values;
+    if (size < 1) size = 1;
+    coord += offset * size;
+}
 
-    void size_slider_cursor(float& coord, float& size, int num_values, int offset) {
-        size /= num_values;
-        if (size < 1) size = 1;
-        coord += offset * size;
+float get_distance_to_slider(float mouse_cursor_coord, float cursor_size, float slider_cursor_coord) {
+    auto half_cursor_size = cursor_size / 2;
+    slider_cursor_coord += half_cursor_size;
+    return mouse_cursor_coord - slider_cursor_coord;
+}
+
+void progress_slider_value(float mouse_cursor_coord, float cursor_size,
+                           float slider_cursor_coord, float step, float& value) {
+    float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
+    if (math::abs(distance) > cursor_size / 2) {
+        value += static_cast<int>(distance / cursor_size) * step;
+    }
+}
+
+enum class SliderOrientation {
+    kHorizontal, kVertical
+};
+
+SliderOrientation calculate_slider_orientation(const Rectangle& rect) {
+    return rect.height > rect.width
+           ? SliderOrientation::kVertical
+           : SliderOrientation::kHorizontal;
+}
+
+struct SliderModel {
+    Rectangle base_area;
+    Rectangle cursor_area;
+    bool is_hovering_over_area = false;
+    bool is_holding_click = false;
+    bool has_value_changed = false;
+};
+
+SliderModel tweak_slider_model(Context& ctx, float* value, const SliderValues& values,
+                               Rectangle* outline_area, Rectangle base_area, Rectangle cursor_area) {
+    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                      && ctx.mouse.left_button.is_held();
+
+    if (is_holding_click_on_slider) {
+        base_area = decrease_rect(base_area, 2);
+        cursor_area = decrease_rect(cursor_area, 4);
     }
 
-    float get_distance_to_slider(float mouse_cursor_coord, float cursor_size, float slider_cursor_coord) {
-        auto half_cursor_size = cursor_size / 2;
-        slider_cursor_coord += half_cursor_size;
-        return mouse_cursor_coord - slider_cursor_coord;
+    bool has_value_changed = false;
+    if (*value != values.value) {
+        *value = math::clamp(values.value, values.min, values.max);
+        has_value_changed = true;
     }
 
-    void progress_slider_value(float mouse_cursor_coord, float cursor_size,
-                               float slider_cursor_coord, float step, float& value) {
-        float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
-        if (math::abs(distance) > cursor_size / 2) {
-            value += static_cast<int>(distance / cursor_size) * step;
-        }
+    return {base_area, cursor_area, is_hovering_over_area, is_holding_click_on_slider, has_value_changed};
+}
+
+SliderModel get_slider_model(Context& ctx, Rectangle* outline_area, float* value, float min, float max, float step) {
+    ctx.fit_rect_in_window(*outline_area);
+    Rectangle base_area = decrease_rect(*outline_area, 4);
+
+    auto values = prepare_slider_values(min, max, *value, step);
+
+    SliderOrientation orientation = calculate_slider_orientation(base_area);
+
+    auto cursor_area = decrease_rect(base_area, 4);
+    if (orientation == SliderOrientation::kHorizontal) {
+        size_slider_cursor(cursor_area.x, cursor_area.width, values.num_values, values.offset);
+    } else {
+        size_slider_cursor(cursor_area.y, cursor_area.height, values.num_values, values.offset);
     }
 
-    enum class SliderOrientation {
-        kHorizontal, kVertical
-    };
+    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                      && ctx.mouse.left_button.is_held();
 
-    SliderOrientation calculate_slider_orientation(const Rectangle& rect) {
-        return rect.height > rect.width
-               ? SliderOrientation::kVertical
-               : SliderOrientation::kHorizontal;
-    }
-
-    struct SliderModel {
-        Rectangle base_area;
-        Rectangle cursor_area;
-        bool is_hovering_over_area = false;
-        bool is_holding_click = false;
-        bool has_value_changed = false;
-    };
-
-    SliderModel tweak_slider_model(Context& ctx, float* value, const SliderValues& values,
-                                   Rectangle* outline_area, Rectangle base_area, Rectangle cursor_area) {
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                    && ctx.mouse.left_button.is_held();
-
-        if (is_holding_click_on_slider) {
-            base_area = decrease_rect(base_area, 2);
-            cursor_area = decrease_rect(cursor_area, 4);
-        }
-
-        bool has_value_changed = false;
-        if (*value != values.value) {
-            *value = math::clamp(values.value, values.min, values.max);
-            has_value_changed = true;
-        }
-
-        return {base_area, cursor_area, is_hovering_over_area, is_holding_click_on_slider, has_value_changed};
-    }
-
-    SliderModel get_slider_model(Context& ctx, Rectangle* outline_area, float* value, float min, float max, float step) {
-        ctx.fit_rect_in_window(*outline_area);
-        Rectangle base_area = decrease_rect(*outline_area, 4);
-
-        auto values = prepare_slider_values(min, max, *value, step);
-
-        SliderOrientation orientation = calculate_slider_orientation(base_area);
-
-        auto cursor_area = decrease_rect(base_area, 4);
+    if (is_holding_click_on_slider) {
         if (orientation == SliderOrientation::kHorizontal) {
-            size_slider_cursor(cursor_area.x, cursor_area.width, values.num_values, values.offset);
+            progress_slider_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
+                                  step, values.value);
         } else {
-            size_slider_cursor(cursor_area.y, cursor_area.height, values.num_values, values.offset);
+            progress_slider_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
+                                  step, values.value);
         }
+    } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
+        values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
+    }
+    return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+}
 
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                          && ctx.mouse.left_button.is_held();
+void size_scrollbar_cursor(float& coord, float& size, float step, int offset, float viewSize) {
+    float scale = size / viewSize;
+    if (scale <= 1.0f) {
+        coord += offset * step * scale;
+        size = math::max(1.0f, scale * size);
+        size = math::min(size, viewSize);
+    }
+}
 
-        if (is_holding_click_on_slider) {
-            if (orientation == SliderOrientation::kHorizontal) {
-                progress_slider_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                      step, values.value);
-            } else {
-                progress_slider_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                      step, values.value);
-            }
-        } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
-            values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
-        }
-        return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+SliderValues prepare_scrollbar_values(float max_scroll, float value, float step) {
+    float min = 0.0f;
+    float max = math::max(0.f, max_scroll);
+    float clamped_value = math::clamp(value, min, max);
+    return SliderValues{
+            min, max, clamped_value,
+            static_cast<int>((value - min) / step),
+            static_cast<int>((max - min) / step + 1)
+    };
+}
+
+void progress_scrollbar_value(float mouse_cursor_coord, float cursor_size,
+                              float slider_cursor_coord, float step, float& value) {
+    float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
+    if (math::abs(distance) > cursor_size / 2) {
+        value += static_cast<int>(distance * step) / cursor_size;
+    }
+}
+
+SliderModel get_scrollbar_model(Context& ctx, Rectangle* outline_area, float view_size, float* value) {
+    ctx.fit_rect_in_window(*outline_area);
+    Rectangle base_area = decrease_rect(*outline_area, 4);
+
+    auto step = ctx.get_font_size();
+
+    SliderOrientation orientation = calculate_slider_orientation(base_area);
+    SliderValues values;
+    if (orientation == SliderOrientation::kVertical) {
+        values = prepare_scrollbar_values(view_size - base_area.height, *value, step);
+    } else {
+        values = prepare_scrollbar_values(view_size - base_area.width, *value, step);
     }
 
-    void size_scrollbar_cursor(float& coord, float& size, float step, int offset, float viewSize) {
-        float scale = size / viewSize;
-        if (scale <= 1.0f) {
-            coord += offset * step * scale;
-            size = math::max(1.0f, scale * size);
-            size = math::min(size, viewSize);
-        }
+    auto cursor_area = decrease_rect(base_area, 4);
+    if (orientation == SliderOrientation::kHorizontal) {
+        size_scrollbar_cursor(cursor_area.x, cursor_area.width, step, values.offset, view_size);
+    } else {
+        size_scrollbar_cursor(cursor_area.y, cursor_area.height, step, values.offset, view_size);
     }
 
-    SliderValues prepare_scrollbar_values(float max_scroll, float value, float step) {
-        float min = 0.0f;
-        float max = math::max(0.f, max_scroll);
-        float clamped_value = math::clamp(value, min, max);
-        return SliderValues{
-                min, max, clamped_value,
-                static_cast<int>((value - min) / step),
-                static_cast<int>((max - min) / step + 1)
-        };
-    }
+    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                      && ctx.mouse.left_button.is_held();
 
-    void progress_scrollbar_value(float mouse_cursor_coord, float cursor_size,
-                                  float slider_cursor_coord, float step, float& value) {
-        float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
-        if (math::abs(distance) > cursor_size / 2) {
-            value += static_cast<int>(distance * step) / cursor_size;
-        }
-    }
-
-    SliderModel get_scrollbar_model(Context& ctx, Rectangle* outline_area, float view_size, float* value) {
-        ctx.fit_rect_in_window(*outline_area);
-        Rectangle base_area = decrease_rect(*outline_area, 4);
-
-        auto step = ctx.get_font_size();
-
-        SliderOrientation orientation = calculate_slider_orientation(base_area);
-        SliderValues values;
-        if (orientation == SliderOrientation::kVertical) {
-            values = prepare_scrollbar_values(view_size - base_area.height, *value, step);
-        } else {
-            values = prepare_scrollbar_values(view_size - base_area.width, *value, step);
-        }
-
-        auto cursor_area = decrease_rect(base_area, 4);
+    if (is_holding_click_on_slider) {
         if (orientation == SliderOrientation::kHorizontal) {
-            size_scrollbar_cursor(cursor_area.x, cursor_area.width, step, values.offset, view_size);
+            progress_scrollbar_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
+                                     step, values.value);
         } else {
-            size_scrollbar_cursor(cursor_area.y, cursor_area.height, step, values.offset, view_size);
+            progress_scrollbar_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
+                                     step, values.value);
         }
-
-        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                          && ctx.mouse.left_button.is_held();
-
-        if (is_holding_click_on_slider) {
-            if (orientation == SliderOrientation::kHorizontal) {
-                progress_scrollbar_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                         step, values.value);
-            } else {
-                progress_scrollbar_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                         step, values.value);
-            }
-        } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
-            values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
-        }
-        return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+    } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
+        values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
     }
+    return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+}
 
-    void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& bounding_box,
-                           const Color& base_color) {
-        Color frame_color = colors::get_yiq_contrast(base_color);
-        ctx.render_rectangle(bounding_box, frame_color);
-        ctx.render_rectangle(model.base_area, base_color);
+void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& bounding_box,
+                       const Color& base_color) {
+    Color frame_color = colors::get_yiq_contrast(base_color);
+    ctx.render_rectangle(bounding_box, frame_color);
+    ctx.render_rectangle(model.base_area, base_color);
 
-        if (model.is_hovering_over_area) {
-            frame_color = colors::lighten_color_by(frame_color, 30);
-        }
-        if (model.is_holding_click) {
-            frame_color = colors::lighten_color_by(frame_color, 30);
-        }
-        ctx.render_rectangle(model.cursor_area, frame_color);
+    if (model.is_hovering_over_area) {
+        frame_color = colors::lighten_color_by(frame_color, 30);
     }
-
-    bool slider(Context& ctx, Rectangle bounding_box, Color base_color,
-                float* value, float min, float max, float step) {
-        assert(value != nullptr && "Can't represent null float");
-        auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
-
-        draw_slider_model(ctx, model, bounding_box, base_color);
-
-        return model.has_value_changed;
+    if (model.is_holding_click) {
+        frame_color = colors::lighten_color_by(frame_color, 30);
     }
+    ctx.render_rectangle(model.cursor_area, frame_color);
+}
 
-    bool scrollbar(Context& ctx, Rectangle bounding_box, Color base_color,
-                   float* value, float view_size) {
-        assert(value != nullptr && "Can't represent null float");
-        auto model = get_scrollbar_model(ctx, &bounding_box, view_size, value);
+bool slider(Context& ctx, Rectangle bounding_box, Color base_color,
+            float* value, float min, float max, float step) {
+    assert(value != nullptr && "Can't represent null float");
+    auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
 
-        draw_slider_model(ctx, model, bounding_box, base_color);
+    draw_slider_model(ctx, model, bounding_box, base_color);
 
-        return model.has_value_changed;
-    }
+    return model.has_value_changed;
+}
 
-    bool textured_slider(Context& ctx, Rectangle bounding_box, int base_texture, int cursor_texture,
-                         float* value, float min, float max, float step) {
-        assert(value != nullptr && "Can't represent null float");
-        auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+bool scrollbar(Context& ctx, Rectangle bounding_box, Color base_color,
+               float* value, float view_size) {
+    assert(value != nullptr && "Can't represent null float");
+    auto model = get_scrollbar_model(ctx, &bounding_box, view_size, value);
 
-        ctx.render_rectangle(bounding_box, base_texture);
-        ctx.render_rectangle(model.cursor_area, cursor_texture);
+    draw_slider_model(ctx, model, bounding_box, base_color);
 
-        return model.has_value_changed;
-    }
+    return model.has_value_changed;
+}
+
+bool textured_slider(Context& ctx, Rectangle bounding_box, int base_texture, int cursor_texture,
+                     float* value, float min, float max, float step) {
+    assert(value != nullptr && "Can't represent null float");
+    auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+
+    ctx.render_rectangle(bounding_box, base_texture);
+    ctx.render_rectangle(model.cursor_area, cursor_texture);
+
+    return model.has_value_changed;
+}
 }

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -6,225 +6,226 @@
 using namespace reig::primitive;
 
 namespace reig::reference_widget {
-struct SliderValues {
-    float min = 0.0f;
-    float max = 0.0f;
-    float value = 0.0f;
-    int offset = 0;
-    int num_values = 0;
-};
-
-SliderValues prepare_slider_values(float min, float max, float value, float step) {
-    float min_end = math::min(min, max);
-    float max_end = math::max(min, max);
-    return SliderValues{
-            min_end, max_end, math::clamp(value, min_end, max_end),
-            static_cast<int>((value - min_end) / step),
-            static_cast<int>((max_end - min_end) / step + 1)
+    struct SliderValues {
+        float min = 0.0f;
+        float max = 0.0f;
+        float value = 0.0f;
+        int offset = 0;
+        int num_values = 0;
     };
-};
 
-void size_slider_cursor(float& coord, float& size, int num_values, int offset) {
-    size /= num_values;
-    if (size < 1) size = 1;
-    coord += offset * size;
-}
-
-float get_distance_to_slider(float mouse_cursor_coord, float cursor_size, float slider_cursor_coord) {
-    auto half_cursor_size = cursor_size / 2;
-    slider_cursor_coord += half_cursor_size;
-    return mouse_cursor_coord - slider_cursor_coord;
-}
-
-void progress_slider_value(float mouse_cursor_coord, float cursor_size,
-                           float slider_cursor_coord, float step, float* value) {
-    float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
-    if (math::abs(distance) > cursor_size / 2) {
-        *value += static_cast<int>(distance / cursor_size) * step;
-    }
-}
-
-enum class SliderOrientation {
-    kHorizontal, kVertical
-};
-
-SliderOrientation calculate_slider_orientation(const Rectangle& rect) {
-    return rect.height > rect.width
-           ? SliderOrientation::kVertical
-           : SliderOrientation::kHorizontal;
-}
-
-struct SliderModel {
-    Rectangle bounding_box;
-    Rectangle cursor_bounding_box;
-    bool is_hovering_over_area = false;
-    bool is_holding_click = false;
-    bool has_value_changed = false;
-};
-
-SliderModel tweak_slider_model(Context& ctx, float* value, const SliderValues& values,
-                               Rectangle* outline_area, Rectangle base_area, Rectangle cursor_area) {
-    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                      && ctx.mouse.left_button.is_held();
-
-    if (is_holding_click_on_slider) {
-        base_area = decrease_rect(base_area, 2);
-        cursor_area = decrease_rect(cursor_area, 4);
-    }
-
-    bool has_value_changed = false;
-    if (*value != values.value) {
-        *value = math::clamp(values.value, values.min, values.max);
-        has_value_changed = true;
-    }
-
-    return {base_area, cursor_area, is_hovering_over_area, is_holding_click_on_slider, has_value_changed};
-}
-
-SliderModel get_slider_model(Context& ctx, Rectangle* outline_area, float* value, float min, float max, float step) {
-    ctx.fit_rect_in_window(*outline_area);
-    Rectangle base_area = decrease_rect(*outline_area, 4);
-
-    auto values = prepare_slider_values(min, max, *value, step);
-
-    SliderOrientation orientation = calculate_slider_orientation(base_area);
-
-    auto cursor_area = decrease_rect(base_area, 4);
-    if (orientation == SliderOrientation::kHorizontal) {
-        size_slider_cursor(cursor_area.x, cursor_area.width, values.num_values, values.offset);
-    } else {
-        size_slider_cursor(cursor_area.y, cursor_area.height, values.num_values, values.offset);
-    }
-
-    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                      && ctx.mouse.left_button.is_held();
-
-    if (is_holding_click_on_slider) {
-        if (orientation == SliderOrientation::kHorizontal) {
-            progress_slider_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                  step, &values.value);
-        } else {
-            progress_slider_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                  step, &values.value);
-        }
-    } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
-        values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
-    }
-    return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
-}
-
-void size_scrollbar_cursor(float& coord, float& size, float step, int offset, float viewSize) {
-    float scale = size / viewSize;
-    if (scale <= 1.0f) {
-        coord += offset * step * scale;
-        size = math::max(1.0f, scale * size);
-        size = math::min(size, viewSize);
-    }
-}
-
-SliderValues prepare_scrollbar_values(float max_scroll, float value, float step) {
-    float min = 0.0f;
-    float max = math::max(0.f, max_scroll);
-    float clamped_value = math::clamp(value, min, max);
-    return SliderValues{
-            min, max, clamped_value,
-            static_cast<int>((value - min) / step),
-            static_cast<int>((max - min) / step + 1)
+    SliderValues prepare_slider_values(float min, float max, float value, float step) {
+        float min_end = math::min(min, max);
+        float max_end = math::max(min, max);
+        return SliderValues{
+                min_end, max_end, math::clamp(value, min_end, max_end),
+                static_cast<int>((value - min_end) / step),
+                static_cast<int>((max_end - min_end) / step + 1)
+        };
     };
-}
 
-void progress_scrollbar_value(float mouse_cursor_coord, float cursor_size,
-                              float slider_cursor_coord, float step, float* value) {
-    float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
-    if (math::abs(distance) > cursor_size / 2) {
-        *value += static_cast<int>(distance * step) / cursor_size;
-    }
-}
-
-SliderModel get_scrollbar_model(Context& ctx, Rectangle* outline_area, float view_size, float* value) {
-    ctx.fit_rect_in_window(*outline_area);
-    Rectangle base_area = decrease_rect(*outline_area, 4);
-
-    auto step = ctx.get_font_size();
-
-    SliderOrientation orientation = calculate_slider_orientation(base_area);
-    SliderValues values;
-    if (orientation == SliderOrientation::kVertical) {
-        values = prepare_scrollbar_values(view_size - base_area.height, *value, step);
-    } else {
-        values = prepare_scrollbar_values(view_size - base_area.width, *value, step);
+    void size_slider_cursor(float& coord, float& size, int num_values, int offset) {
+        size /= num_values;
+        if (size < 1) size = 1;
+        coord += offset * size;
     }
 
-    auto cursor_area = decrease_rect(base_area, 4);
-    if (orientation == SliderOrientation::kHorizontal) {
-        size_scrollbar_cursor(cursor_area.x, cursor_area.width, step, values.offset, view_size);
-    } else {
-        size_scrollbar_cursor(cursor_area.y, cursor_area.height, step, values.offset, view_size);
+    float get_distance_to_slider(float mouse_cursor_coord, float cursor_size, float slider_cursor_coord) {
+        auto half_cursor_size = cursor_size / 2;
+        slider_cursor_coord += half_cursor_size;
+        return mouse_cursor_coord - slider_cursor_coord;
     }
 
-    bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
-    bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
-                                      && ctx.mouse.left_button.is_held();
-
-    if (is_holding_click_on_slider) {
-        if (orientation == SliderOrientation::kHorizontal) {
-            progress_scrollbar_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                     step, &values.value);
-        } else {
-            progress_scrollbar_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                     step, &values.value);
+    void progress_slider_value(float mouse_cursor_coord, float cursor_size,
+                               float slider_cursor_coord, float step, float* value) {
+        float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
+        if (math::abs(distance) > cursor_size / 2) {
+            *value += static_cast<int>(distance / cursor_size) * step;
         }
-    } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
-        values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
     }
-    return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
-}
 
-void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& bounding_box,
-                       const Color& base_color) {
-    Color frame_color = colors::get_yiq_contrast(base_color);
-    ctx.render_rectangle(bounding_box, frame_color);
-    ctx.render_rectangle(model.bounding_box, base_color);
+    enum class SliderOrientation {
+        kHorizontal, kVertical
+    };
 
-    if (model.is_hovering_over_area) {
-        frame_color = colors::lighten_color_by(frame_color, 30);
+    SliderOrientation calculate_slider_orientation(const Rectangle& rect) {
+        return rect.height > rect.width
+               ? SliderOrientation::kVertical
+               : SliderOrientation::kHorizontal;
     }
-    if (model.is_holding_click) {
-        frame_color = colors::lighten_color_by(frame_color, 30);
+
+    struct SliderModel {
+        Rectangle bounding_box;
+        Rectangle cursor_bounding_box;
+        bool is_hovering_over_area = false;
+        bool is_holding_click = false;
+        bool has_value_changed = false;
+    };
+
+    SliderModel tweak_slider_model(Context& ctx, float* value, const SliderValues& values,
+                                   Rectangle* outline_area, Rectangle base_area, Rectangle cursor_area) {
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                          && ctx.mouse.left_button.is_held();
+
+        if (is_holding_click_on_slider) {
+            base_area = decrease_rect(base_area, 2);
+            cursor_area = decrease_rect(cursor_area, 4);
+        }
+
+        bool has_value_changed = false;
+        if (*value != values.value) {
+            *value = math::clamp(values.value, values.min, values.max);
+            has_value_changed = true;
+        }
+
+        return {base_area, cursor_area, is_hovering_over_area, is_holding_click_on_slider, has_value_changed};
     }
-    ctx.render_rectangle(model.cursor_bounding_box, frame_color);
-}
 
-bool slider(Context& ctx, Rectangle bounding_box, Color base_color,
-            float* value, float min, float max, float step) {
-    assert(value != nullptr && "Can't represent null float");
-    auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+    SliderModel
+    get_slider_model(Context& ctx, Rectangle* outline_area, float* value, float min, float max, float step) {
+        ctx.fit_rect_in_window(*outline_area);
+        Rectangle base_area = decrease_rect(*outline_area, 4);
 
-    draw_slider_model(ctx, model, bounding_box, base_color);
+        auto values = prepare_slider_values(min, max, *value, step);
 
-    return model.has_value_changed;
-}
+        SliderOrientation orientation = calculate_slider_orientation(base_area);
 
-bool scrollbar(Context& ctx, Rectangle bounding_box, Color base_color,
-               float* value, float view_size) {
-    assert(value != nullptr && "Can't represent null float");
-    auto model = get_scrollbar_model(ctx, &bounding_box, view_size, value);
+        auto cursor_area = decrease_rect(base_area, 4);
+        if (orientation == SliderOrientation::kHorizontal) {
+            size_slider_cursor(cursor_area.x, cursor_area.width, values.num_values, values.offset);
+        } else {
+            size_slider_cursor(cursor_area.y, cursor_area.height, values.num_values, values.offset);
+        }
 
-    draw_slider_model(ctx, model, bounding_box, base_color);
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                          && ctx.mouse.left_button.is_held();
 
-    return model.has_value_changed;
-}
+        if (is_holding_click_on_slider) {
+            if (orientation == SliderOrientation::kHorizontal) {
+                progress_slider_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
+                                      step, &values.value);
+            } else {
+                progress_slider_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
+                                      step, &values.value);
+            }
+        } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
+            values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
+        }
+        return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+    }
 
-bool textured_slider(Context& ctx, Rectangle bounding_box, int base_texture, int cursor_texture,
-                     float* value, float min, float max, float step) {
-    assert(value != nullptr && "Can't represent null float");
-    auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+    void size_scrollbar_cursor(float& coord, float& size, float step, int offset, float viewSize) {
+        float scale = size / viewSize;
+        if (scale <= 1.0f) {
+            coord += offset * step * scale;
+            size = math::max(1.0f, scale * size);
+            size = math::min(size, viewSize);
+        }
+    }
 
-    ctx.render_rectangle(bounding_box, base_texture);
-    ctx.render_rectangle(model.cursor_bounding_box, cursor_texture);
+    SliderValues prepare_scrollbar_values(float max_scroll, float value, float step) {
+        float min = 0.0f;
+        float max = math::max(0.f, max_scroll);
+        float clamped_value = math::clamp(value, min, max);
+        return SliderValues{
+                min, max, clamped_value,
+                static_cast<int>((value - min) / step),
+                static_cast<int>((max - min) / step + 1)
+        };
+    }
 
-    return model.has_value_changed;
-}
+    void progress_scrollbar_value(float mouse_cursor_coord, float cursor_size,
+                                  float slider_cursor_coord, float step, float* value) {
+        float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
+        if (math::abs(distance) > cursor_size / 2) {
+            *value += static_cast<int>(distance * step) / cursor_size;
+        }
+    }
+
+    SliderModel get_scrollbar_model(Context& ctx, Rectangle* outline_area, float view_size, float* value) {
+        ctx.fit_rect_in_window(*outline_area);
+        Rectangle base_area = decrease_rect(*outline_area, 4);
+
+        auto step = ctx.get_font_size();
+
+        SliderOrientation orientation = calculate_slider_orientation(base_area);
+        SliderValues values;
+        if (orientation == SliderOrientation::kVertical) {
+            values = prepare_scrollbar_values(view_size - base_area.height, *value, step);
+        } else {
+            values = prepare_scrollbar_values(view_size - base_area.width, *value, step);
+        }
+
+        auto cursor_area = decrease_rect(base_area, 4);
+        if (orientation == SliderOrientation::kHorizontal) {
+            size_scrollbar_cursor(cursor_area.x, cursor_area.width, step, values.offset, view_size);
+        } else {
+            size_scrollbar_cursor(cursor_area.y, cursor_area.height, step, values.offset, view_size);
+        }
+
+        bool is_hovering_over_area = ctx.mouse.is_hovering_over_rect(*outline_area);
+        bool is_holding_click_on_slider = ctx.mouse.left_button.clicked_in_rect(*outline_area)
+                                          && ctx.mouse.left_button.is_held();
+
+        if (is_holding_click_on_slider) {
+            if (orientation == SliderOrientation::kHorizontal) {
+                progress_scrollbar_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
+                                         step, &values.value);
+            } else {
+                progress_scrollbar_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
+                                         step, &values.value);
+            }
+        } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
+            values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;
+        }
+        return tweak_slider_model(ctx, value, values, outline_area, base_area, cursor_area);
+    }
+
+    void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& bounding_box,
+                           const Color& base_color) {
+        Color frame_color = colors::get_yiq_contrast(base_color);
+        ctx.render_rectangle(bounding_box, frame_color);
+        ctx.render_rectangle(model.bounding_box, base_color);
+
+        if (model.is_hovering_over_area) {
+            frame_color = colors::lighten_color_by(frame_color, 30);
+        }
+        if (model.is_holding_click) {
+            frame_color = colors::lighten_color_by(frame_color, 30);
+        }
+        ctx.render_rectangle(model.cursor_bounding_box, frame_color);
+    }
+
+    bool slider(Context& ctx, Rectangle bounding_box, Color base_color,
+                float* value, float min, float max, float step) {
+        assert(value != nullptr && "Can't represent null float");
+        auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+
+        draw_slider_model(ctx, model, bounding_box, base_color);
+
+        return model.has_value_changed;
+    }
+
+    bool scrollbar(Context& ctx, Rectangle bounding_box, Color base_color,
+                   float* value, float view_size) {
+        assert(value != nullptr && "Can't represent null float");
+        auto model = get_scrollbar_model(ctx, &bounding_box, view_size, value);
+
+        draw_slider_model(ctx, model, bounding_box, base_color);
+
+        return model.has_value_changed;
+    }
+
+    bool textured_slider(Context& ctx, Rectangle bounding_box, int base_texture, int cursor_texture,
+                         float* value, float min, float max, float step) {
+        assert(value != nullptr && "Can't represent null float");
+        auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
+
+        ctx.render_rectangle(bounding_box, base_texture);
+        ctx.render_rectangle(model.cursor_bounding_box, cursor_texture);
+
+        return model.has_value_changed;
+    }
 }

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -55,8 +55,8 @@ SliderOrientation calculate_slider_orientation(const Rectangle& rect) {
 }
 
 struct SliderModel {
-    Rectangle base_area;
-    Rectangle cursor_area;
+    Rectangle bounding_box;
+    Rectangle cursor_bounding_box;
     bool is_hovering_over_area = false;
     bool is_holding_click = false;
     bool has_value_changed = false;
@@ -186,7 +186,7 @@ void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& 
                        const Color& base_color) {
     Color frame_color = colors::get_yiq_contrast(base_color);
     ctx.render_rectangle(bounding_box, frame_color);
-    ctx.render_rectangle(model.base_area, base_color);
+    ctx.render_rectangle(model.bounding_box, base_color);
 
     if (model.is_hovering_over_area) {
         frame_color = colors::lighten_color_by(frame_color, 30);
@@ -194,7 +194,7 @@ void draw_slider_model(Context& ctx, const SliderModel& model, const Rectangle& 
     if (model.is_holding_click) {
         frame_color = colors::lighten_color_by(frame_color, 30);
     }
-    ctx.render_rectangle(model.cursor_area, frame_color);
+    ctx.render_rectangle(model.cursor_bounding_box, frame_color);
 }
 
 bool slider(Context& ctx, Rectangle bounding_box, Color base_color,
@@ -223,7 +223,7 @@ bool textured_slider(Context& ctx, Rectangle bounding_box, int base_texture, int
     auto model = get_slider_model(ctx, &bounding_box, value, min, max, step);
 
     ctx.render_rectangle(bounding_box, base_texture);
-    ctx.render_rectangle(model.cursor_area, cursor_texture);
+    ctx.render_rectangle(model.cursor_bounding_box, cursor_texture);
 
     return model.has_value_changed;
 }

--- a/lib/reig/reference_widget_slider.cpp
+++ b/lib/reig/reference_widget_slider.cpp
@@ -136,10 +136,10 @@ SliderValues prepare_scrollbar_values(float max_scroll, float value, float step)
 }
 
 void progress_scrollbar_value(float mouse_cursor_coord, float cursor_size,
-                              float slider_cursor_coord, float step, float& value) {
+                              float slider_cursor_coord, float step, float* value) {
     float distance = get_distance_to_slider(mouse_cursor_coord, cursor_size, slider_cursor_coord);
     if (math::abs(distance) > cursor_size / 2) {
-        value += static_cast<int>(distance * step) / cursor_size;
+        *value += static_cast<int>(distance * step) / cursor_size;
     }
 }
 
@@ -171,10 +171,10 @@ SliderModel get_scrollbar_model(Context& ctx, Rectangle* outline_area, float vie
     if (is_holding_click_on_slider) {
         if (orientation == SliderOrientation::kHorizontal) {
             progress_scrollbar_value(ctx.mouse.get_cursor_pos().x, cursor_area.width, cursor_area.x,
-                                     step, values.value);
+                                     step, &values.value);
         } else {
             progress_scrollbar_value(ctx.mouse.get_cursor_pos().y, cursor_area.height, cursor_area.y,
-                                     step, values.value);
+                                     step, &values.value);
         }
     } else if (ctx.mouse.get_scrolled() != 0 && is_hovering_over_area) {
         values.value += static_cast<int>(ctx.mouse.get_scrolled()) * step;


### PR DESCRIPTION
Closes #81 

Changes proposed:
- Remove resized bounding box areas from models, leave only bounding boxes and state
- Use pass by pointer instead of pass by reference as per google style guide