### PR TITLE
Converge previous_windows and queued_windows into one container

### DIFF
--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -116,10 +116,7 @@ namespace reig {
                                                });
 
             if (previous_window != _previous_windows.end()) {
-                previous_window->set_width(queued_window.width());
-                previous_window->set_height(queued_window.height());
-                previous_window->set_x(queued_window.x());
-                previous_window->set_y(queued_window.y());
+                update_window(*previous_window, queued_window);
             } else {
                 _previous_windows.insert(_previous_windows.begin(), queued_window);
             }

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -155,10 +155,9 @@ namespace reig {
     void Context::start_window(gsl::czstring id, gsl::czstring title, float default_x, float default_y) {
         if (!_windows.empty()) end_window();
 
-        auto window = std::find_if(_windows.begin(), _windows.end(),
-                                           [id](const Window& window) {
-                                               return window.id() == id;
-                                           });
+        auto window = std::find_if(_windows.begin(), _windows.end(), [id](const Window& window) {
+            return window.id() == id;
+        });
         if (window != _windows.end()) {
             detail::restart_window(*window, title);
         } else {

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -117,10 +117,9 @@ namespace reig {
     }
 
     void Context::remove_unqueued_windows() {
-        auto remove_from = std::remove_if(_windows.begin(), _windows.end(),
-                                          [](const Window& window) {
-                                              return !window.is_queued();
-                                          });
+        auto remove_from = std::remove_if(_windows.begin(), _windows.end(), [](const Window& window) {
+            return !window.is_queued();
+        });
         _windows.erase(remove_from, _windows.end());
     }
 

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -149,10 +149,10 @@ namespace reig {
         });
         if (window != _windows.end()) {
             detail::restart_window(*window, title);
-            _current_window = &*window;
+            _queued_window = &*window;
         } else {
             _windows.emplace(_windows.begin(), id, title, default_x, default_y, 0, 0, _font.height + 8);
-            _current_window = &_windows.front();
+            _queued_window = &_windows.front();
         }
     }
 
@@ -208,10 +208,10 @@ namespace reig {
     void Context::end_window() {
         if (_windows.empty()) return;
 
-        if (_current_window != nullptr) {
-            _current_window->set_finished(true);
-            handle_window_input(*_current_window);
-            _current_window = nullptr;
+        if (_queued_window != nullptr) {
+            _queued_window->set_finished(true);
+            handle_window_input(*_queued_window);
+            _queued_window = nullptr;
         }
     }
 
@@ -245,8 +245,8 @@ namespace reig {
     bool reig::Context::is_window_body_point_visible(const primitive::Point& point) {
         for (auto& window : _windows) {
             if (is_point_in_rect(point, get_window_body_rect(window))) {
-                if (_current_window) {
-                    return _current_window->id() == window.id();
+                if (_queued_window) {
+                    return _queued_window->id() == window.id();
                 } else {
                     return false;
                 }
@@ -256,14 +256,14 @@ namespace reig {
     }
 
     void Context::fit_rect_in_window(Rectangle& rect) {
-        if (_current_window != nullptr) {
-            detail::fit_rect_in_window(rect, *_current_window);
+        if (_queued_window != nullptr) {
+            detail::fit_rect_in_window(rect, *_queued_window);
         }
     }
 
     DrawData& Context::get_current_draw_data_buffer() {
-        if (_current_window) {
-            return _current_window->draw_data();
+        if (_queued_window) {
+            return _queued_window->draw_data();
         } else {
             return _free_draw_data;
         }

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -157,19 +157,6 @@ namespace reig {
         }
     }
 
-    void Context::start_frame() {
-        mouse.left_button._is_clicked = false;
-        mouse._scrolled = 0.f;
-
-        keyboard.reset();
-
-        ++_frame_counter;
-    }
-
-    unsigned Context::get_frame_counter() const {
-        return _frame_counter;
-    }
-
     detail::Window* Context::get_current_window() {
         if (!_queued_windows.empty() && !_queued_windows.back().is_finished()) {
             return &_queued_windows.back();
@@ -313,6 +300,28 @@ namespace reig {
         }
     }
 
+    DrawData& Context::get_current_draw_data_buffer() {
+        auto* current_window = get_current_window();
+        if (current_window) {
+            return current_window->draw_data();
+        } else {
+            return _free_draw_data;
+        }
+    }
+
+    void Context::start_frame() {
+        mouse.left_button._is_clicked = false;
+        mouse._scrolled = 0.f;
+
+        keyboard.reset();
+
+        ++_frame_counter;
+    }
+
+    unsigned Context::get_frame_counter() const {
+        return _frame_counter;
+    }
+
     bool has_alignment(text::Alignment container, text::Alignment alignment) {
         auto container_as_uint = static_cast<unsigned>(container);
         auto alignment_as_uint = static_cast<unsigned>(alignment);
@@ -398,15 +407,6 @@ namespace reig {
         render_text_quads(draw_data, quads, horizontal_alignment, vertical_alignment, _font.texture_id);
 
         return x;
-    }
-
-    DrawData& Context::get_current_draw_data_buffer() {
-        auto* current_window = get_current_window();
-        if (current_window) {
-            return current_window->draw_data();
-        } else {
-            return _free_draw_data;
-        }
     }
 
     void Context::render_rectangle(const Rectangle& rect, const Color& color) {

--- a/lib/reig/context.cpp
+++ b/lib/reig/context.cpp
@@ -165,11 +165,7 @@ namespace reig {
                                                return window.id() == id;
                                            });
         if (previous_window != _windows.end()) {
-            previous_window->set_queued(true);
-            previous_window->set_finished(false);
-            previous_window->set_title(title);
-            previous_window->set_width(0);
-            previous_window->set_height(0);
+            detail::restart_window(*previous_window, title);
         } else {
             _windows.emplace(_windows.begin(), id, title, default_x, default_y, 0, 0, _font.height + 8);
         }

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -152,9 +152,9 @@ namespace reig {
 
         void render_windows();
 
-        void update_previous_windows();
+        void update_window_layers();
 
-        void cleanup_previous_windows();
+        void remove_unqueued_windows();
 
         bool handle_window_focus(const detail::Window& window, bool is_claiming);
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -167,9 +167,8 @@ namespace reig {
         friend ::reig::detail::Mouse;
         friend ::reig::detail::MouseButton;
 
-        detail::Window* get_current_window();
-
         gsl::czstring _dragged_window = nullptr;
+        detail::Window* _current_window = nullptr;
         std::vector<detail::Window> _windows;
         DrawData _free_draw_data;
 

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -170,8 +170,7 @@ namespace reig {
         detail::Window* get_current_window();
 
         gsl::czstring _dragged_window = nullptr;
-        std::vector<detail::Window> _previous_windows;
-        std::vector<detail::Window> _queued_windows;
+        std::vector<detail::Window> _windows;
         DrawData _free_draw_data;
 
         detail::Font _font;

--- a/lib/reig/context.h
+++ b/lib/reig/context.h
@@ -168,7 +168,7 @@ namespace reig {
         friend ::reig::detail::MouseButton;
 
         gsl::czstring _dragged_window = nullptr;
-        detail::Window* _current_window = nullptr;
+        detail::Window* _queued_window = nullptr;
         std::vector<detail::Window> _windows;
         DrawData _free_draw_data;
 

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -6,10 +6,10 @@ namespace reig::detail {
         rect.y += window.y() + window.title_bar_height() + 4;
 
         if (window.x() + window.width() < get_x2(rect)) {
-            window.set_width(get_x2(rect) - window.x());
+            window.set_width(get_x2(rect) - window.x() + 4);
         }
         if (window.y() + window.height() < get_y2(rect)) {
-            window.set_height(get_y2(rect) - window.y());
+            window.set_height(get_y2(rect) - window.y() + 4);
         }
         if (rect.x < window.x()) {
             rect.x = window.x() + 4;

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -31,10 +31,11 @@ namespace reig::detail {
         return {window.x(), window.y() + window.title_bar_height(), window.width(), window.height() - window.title_bar_height()};
     }
 
-    void update_window(Window& old_window, const Window& new_window) {
-        old_window.set_x(new_window.x());
-        old_window.set_y(new_window.y());
-        old_window.set_width(new_window.width());
-        old_window.set_height(new_window.height());
+    void restart_window(Window& window, gsl::czstring title) {
+        window.set_queued(true);
+        window.set_finished(false);
+        window.set_title(title);
+        window.set_width(0.0f);
+        window.set_height(0.0f);
     }
 }

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -2,32 +2,32 @@
 
 namespace reig::detail {
     void fit_rect_in_window(reig::primitive::Rectangle& rect, Window& window) {
-        rect.x += window.x + 4;
-        rect.y += window.y + window.title_bar_height + 4;
+        rect.x += window.x() + 4;
+        rect.y += window.y() + window.title_bar_height() + 4;
 
-        if (window.x + window.width < get_x2(rect)) {
-            window.width = get_x2(rect) - window.x;
+        if (window.x() + window.width() < get_x2(rect)) {
+            window.set_width(get_x2(rect) - window.x());
         }
-        if (window.y + window.height < get_y2(rect)) {
-            window.height = get_y2(rect) - window.y;
+        if (window.y() + window.height() < get_y2(rect)) {
+            window.set_height(get_y2(rect) - window.y());
         }
-        if (rect.x < window.x) {
-            rect.x = window.x + 4;
+        if (rect.x < window.x()) {
+            rect.x = window.x() + 4;
         }
-        if (rect.y < window.y) {
-            rect.y = window.y + 4;
+        if (rect.y < window.y()) {
+            rect.y = window.y() + 4;
         }
     }
 
     primitive::Rectangle get_full_window_rect(const Window& window) {
-        return {window.x, window.y, window.width, window.height};
+        return {window.x(), window.y(), window.width(), window.height()};
     }
 
     primitive::Rectangle get_window_header_rect(const Window& window) {
-        return {window.x, window.y, window.width, window.title_bar_height};
+        return {window.x(), window.y(), window.width(), window.title_bar_height()};
     }
 
     primitive::Rectangle get_window_body_rect(const Window& window) {
-        return {window.x, window.y + window.title_bar_height, window.width, window.height - window.title_bar_height};
+        return {window.x(), window.y() + window.title_bar_height(), window.width(), window.height() - window.title_bar_height()};
     }
 }

--- a/lib/reig/window.cpp
+++ b/lib/reig/window.cpp
@@ -30,4 +30,11 @@ namespace reig::detail {
     primitive::Rectangle get_window_body_rect(const Window& window) {
         return {window.x(), window.y() + window.title_bar_height(), window.width(), window.height() - window.title_bar_height()};
     }
+
+    void update_window(Window& old_window, const Window& new_window) {
+        old_window.set_x(new_window.x());
+        old_window.set_y(new_window.y());
+        old_window.set_width(new_window.width());
+        old_window.set_height(new_window.height());
+    }
 }

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -5,22 +5,64 @@
 #include "gsl.h"
 
 namespace reig::detail {
-    struct Window {
-        Window(gsl::czstring title, float x, float y, float width, float height, float titleBarHeight)
-                : Window{title, title, x, y, width, height, titleBarHeight} {}
+    class Window {
+    public:
+        Window(gsl::czstring title, float x, float y, float width, float height, float title_bar_height)
+                : Window{title, title, x, y, width, height, title_bar_height} {}
 
-        Window(gsl::czstring id, gsl::czstring title, float x, float y, float width, float height, float titleBarHeight)
-                : title{title}, id{id}, x{x}, y{y}, width{width}, height{height}, title_bar_height{titleBarHeight} {}
+        Window(gsl::czstring id, gsl::czstring title, float x, float y,
+               float width, float height, float title_bar_height)
+                : _title{title}, _id{id}, _x{x}, _y{y}, _width{width}, _height{height},
+                  _title_bar_height{title_bar_height} {}
 
-        DrawData draw_data;
-        gsl::czstring title = "";
-        gsl::czstring id = nullptr;
-        float x = 0.0f;
-        float y = 0.0f;
-        float width = 0.f;
-        float height = 0.f;
-        float title_bar_height = 0.f;
-        bool is_finished = false;
+        DrawData& draw_data() {
+            return _draw_data;
+        }
+
+        const DrawData& draw_data() const {
+            return _draw_data;
+        }
+
+        gsl::czstring title() const {
+            return _title;
+        }
+
+        gsl::czstring id() const {
+            return _id;
+        }
+
+        float x() const { return _x; }
+
+        void set_x(float x) { _x = x; }
+
+        float y() const { return _y; }
+
+        void set_y(float y) { _y = y; }
+
+        float width() const { return _width; }
+
+        void set_width(float width) { _width = width; }
+
+        float height() const { return _height; }
+
+        void set_height(float height) { _height = height; }
+
+        float title_bar_height() const { return _title_bar_height; }
+
+        bool is_finished() const { return _is_finished; }
+
+        void finish() { _is_finished = true; }
+
+    private:
+        DrawData _draw_data;
+        gsl::czstring _title = "";
+        gsl::czstring _id = nullptr;
+        float _x = 0.0f;
+        float _y = 0.0f;
+        float _width = 0.f;
+        float _height = 0.f;
+        float _title_bar_height = 0.f;
+        bool _is_finished = false;
     };
 
     /**

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -57,16 +57,21 @@ namespace reig::detail {
 
         void set_collapsed(bool is_collapsed) { _is_collapsed = is_collapsed; }
 
+        bool is_queued() const { return _is_queued; }
+
+        void set_queued(bool is_queued) { _is_queued = is_queued; }
+
     private:
         DrawData _draw_data;
         gsl::czstring _title = "";
         gsl::czstring _id = nullptr;
         float _x = 0.0f;
         float _y = 0.0f;
-        float _width = 0.f;
-        float _height = 0.f;
-        float _title_bar_height = 0.f;
+        float _width = 0.0f;
+        float _height = 0.0f;
+        float _title_bar_height = 0.0f;
         bool _is_finished = false;
+        bool _is_queued = false;
         bool _is_collapsed = false;
     };
 

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -27,6 +27,10 @@ namespace reig::detail {
             return _title;
         }
 
+        void set_title(gsl::czstring title) {
+            _title = title;
+        }
+
         gsl::czstring id() const {
             return _id;
         }
@@ -51,7 +55,7 @@ namespace reig::detail {
 
         bool is_finished() const { return _is_finished; }
 
-        void finish() { _is_finished = true; }
+        void set_finished(bool is_finished) { _is_finished = is_finished; }
 
         bool is_collapsed() const { return _is_collapsed; }
 
@@ -70,8 +74,8 @@ namespace reig::detail {
         float _width = 0.0f;
         float _height = 0.0f;
         float _title_bar_height = 0.0f;
+        bool _is_queued = true;
         bool _is_finished = false;
-        bool _is_queued = false;
         bool _is_collapsed = false;
     };
 

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -53,6 +53,10 @@ namespace reig::detail {
 
         void finish() { _is_finished = true; }
 
+        bool is_collapsed() const { return _is_collapsed; }
+
+        void set_collapsed(bool is_collapsed) { _is_collapsed = is_collapsed; }
+
     private:
         DrawData _draw_data;
         gsl::czstring _title = "";
@@ -63,6 +67,7 @@ namespace reig::detail {
         float _height = 0.f;
         float _title_bar_height = 0.f;
         bool _is_finished = false;
+        bool _is_collapsed = false;
     };
 
     /**

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -93,7 +93,7 @@ namespace reig::detail {
 
     primitive::Rectangle get_window_body_rect(const Window& window);
 
-    void update_window(Window& old_window, const Window& new_window);
+    void restart_window(Window& old_window, gsl::czstring title);
 }
 
 #endif //REIG_WINDOW_H

--- a/lib/reig/window.h
+++ b/lib/reig/window.h
@@ -78,6 +78,8 @@ namespace reig::detail {
     primitive::Rectangle get_window_header_rect(const Window& window);
 
     primitive::Rectangle get_window_body_rect(const Window& window);
+
+    void update_window(Window& old_window, const Window& new_window);
 }
 
 #endif //REIG_WINDOW_H


### PR DESCRIPTION
Changes proposed:
- Make Window a class instead of a struct
- Use a single _windows vector instead of _previous_windows and _queued_windows
- Add is_queued, is_collapsed flags to Window

